### PR TITLE
Feat/4/factory-memory-store-and-mem-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ Headless / CI still uses the script (never merges):
 ./factory.sh telemetry --question "login 500s last 24h"
 ./factory.sh telemetry --question "where does onboarding die, last 7d"
 ./factory.sh qa --repo frontend --pr 12 --url http://localhost:3000
+./factory.sh mem write --lane feature --status started --issue 12 --harness grok --summary "Add the memory store"
+./factory.sh mem read --issue 12
 ```
+
+Lane runs on this machine are stored in `~/.factory/memory/factory.db`. Not git. GitHub comments stay the public ledger.
 
 ## Hard rules
 

--- a/factory.sh
+++ b/factory.sh
@@ -16,9 +16,12 @@ Usage:
   factory.sh telemetry        --question "<what broke>" [--yes]
   factory.sh qa               --repo <name> --pr <n> [--url <app>]
   factory.sh qa               --url <app>
+  factory.sh mem read         [--issue <n>] [--project owner/name] [--limit n]
+  factory.sh mem write        --lane <lane> --status started|done|blocked|failed [--harness grok|claude|codex|cursor] [--issue <n>] [--pr <n>] [--project owner/name] [--summary s] [--next-steps s] [--evidence url-or-json]
 
 Never merges. A person merges.
 FACTORY_WORKSPACE, FACTORY_OWNER, FACTORY_RUNNER can be set instead of flags.
+Memory: FACTORY_MEMORY_DB (default ~/.factory/memory/factory.db).
 EOF
   exit 1
 }
@@ -37,12 +40,28 @@ detect_runner() {
 LANE="${1:-}"
 [[ -n "$LANE" ]] || usage
 shift || usage
+MEM_CMD=""
+if [[ "$LANE" == "mem" ]]; then
+  MEM_CMD="${1:-}"
+  case "$MEM_CMD" in
+    read|write) shift ;;
+    *) usage ;;
+  esac
+fi
 REPO=""
 ISSUE=""
 PR=""
 URL=""
 QUESTION=""
 YES=0
+HARNESS=""
+RUN_LANE=""
+PROJECT=""
+STATUS=""
+SUMMARY=""
+NEXT_STEPS=""
+EVIDENCE=""
+LIMIT=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -52,6 +71,14 @@ while [[ $# -gt 0 ]]; do
     --url) URL="${2:-}"; shift 2 ;;
     --owner) OWNER="${2:-}"; shift 2 ;;
     --runner) RUNNER="${2:-}"; shift 2 ;;
+    --harness) HARNESS="${2:-}"; shift 2 ;;
+    --lane) RUN_LANE="${2:-}"; shift 2 ;;
+    --project) PROJECT="${2:-}"; shift 2 ;;
+    --status) STATUS="${2:-}"; shift 2 ;;
+    --summary) SUMMARY="${2:-}"; shift 2 ;;
+    --next-steps) NEXT_STEPS="${2:-}"; shift 2 ;;
+    --evidence) EVIDENCE="${2:-}"; shift 2 ;;
+    --limit) LIMIT="${2:-}"; shift 2 ;;
     --question) QUESTION="${2:-}"; shift 2 ;;
     --yes) YES=1; shift ;;
     -h|--help) usage ;;
@@ -59,7 +86,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-detect_runner
+if [[ "$LANE" != "mem" ]]; then
+  detect_runner
+fi
 
 need_owner() { [[ -n "$OWNER" ]] || { echo "Need --owner or FACTORY_OWNER" >&2; exit 1; }; }
 need_issue() { [[ -n "$ISSUE" ]] || { echo "Need --issue <n>" >&2; exit 1; }; }
@@ -124,7 +153,174 @@ pr_url() {
   printf 'https://github.com/%s/%s/pull/%s\n' "$OWNER" "$REPO" "$1"
 }
 
+sql_quote() {
+  local s="$1"
+  s=${s//"'"/"''"}
+  printf "'%s'" "$s"
+}
+
+sql_nullable() {
+  if [[ -z "${1:-}" ]]; then
+    printf 'NULL'
+  else
+    sql_quote "$1"
+  fi
+}
+
+json_quote() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '"%s"' "$s"
+}
+
+memory_db() {
+  printf '%s\n' "${FACTORY_MEMORY_DB:-$HOME/.factory/memory/factory.db}"
+}
+
+need_sqlite() {
+  command -v sqlite3 >/dev/null 2>&1 || { echo "sqlite3 not installed" >&2; exit 1; }
+}
+
+memory_init() {
+  local db
+  db="$(memory_db)"
+  mkdir -p "$(dirname "$db")"
+  need_sqlite
+  sqlite3 "$db" "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;" >/dev/null
+  sqlite3 "$db" <<'SQL'
+CREATE TABLE IF NOT EXISTS schema_versions (
+  id INTEGER PRIMARY KEY,
+  version INTEGER UNIQUE NOT NULL,
+  applied_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  harness TEXT NOT NULL CHECK(harness IN ('claude', 'cursor', 'codex', 'grok')),
+  lane TEXT NOT NULL,
+  project TEXT NOT NULL,
+  issue TEXT,
+  pr TEXT,
+  status TEXT NOT NULL CHECK(status IN ('started', 'done', 'blocked', 'failed')),
+  summary TEXT,
+  next_steps TEXT,
+  evidence TEXT NOT NULL DEFAULT '[]',
+  started_at TEXT NOT NULL,
+  started_at_epoch INTEGER NOT NULL,
+  completed_at TEXT,
+  completed_at_epoch INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_runs_project_time ON runs(project, started_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_runs_issue_time ON runs(issue, started_at_epoch DESC);
+CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
+INSERT OR IGNORE INTO schema_versions (version, applied_at)
+VALUES (1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));
+SQL
+}
+
+detect_project() {
+  if [[ -n "${PROJECT:-}" ]]; then
+    return
+  fi
+  if [[ -n "$OWNER" && -n "$REPO" ]]; then
+    PROJECT="$OWNER/$REPO"
+    return
+  fi
+  local url=""
+  url="$(git -C "$WORKSPACE" remote get-url origin 2>/dev/null || true)"
+  if [[ -z "$url" ]]; then
+    url="$(git remote get-url origin 2>/dev/null || true)"
+  fi
+  [[ -n "$url" ]] || { echo "Need --project owner/name" >&2; exit 1; }
+  PROJECT="$(printf '%s' "$url" | sed -E -e 's#^[a-zA-Z0-9+.-]+://##' -e 's#^git@##' -e 's#^[^:/]+[:/]##' -e 's#\.git$##')"
+}
+
+normalize_evidence() {
+  if [[ -z "${EVIDENCE:-}" ]]; then
+    EVIDENCE='[]'
+    return
+  fi
+  if [[ "$EVIDENCE" == \[* ]]; then
+    return
+  fi
+  EVIDENCE="[$(json_quote "$EVIDENCE")]"
+}
+
+mem_read() {
+  local db where sql
+  db="$(memory_db)"
+  if [[ ! -f "$db" ]]; then
+    echo "No factory memory yet at $db" >&2
+    exit 0
+  fi
+  need_sqlite
+  LIMIT="${LIMIT:-10}"
+  [[ "$LIMIT" =~ ^[0-9]+$ ]] || { echo "Need --limit <n>" >&2; exit 1; }
+  where=""
+  if [[ -n "$ISSUE" ]]; then
+    where="issue = $(sql_quote "$ISSUE")"
+  fi
+  if [[ -n "$PROJECT" ]]; then
+    if [[ -n "$where" ]]; then
+      where="$where AND project = $(sql_quote "$PROJECT")"
+    else
+      where="project = $(sql_quote "$PROJECT")"
+    fi
+  fi
+  sql="SELECT id, harness, lane, project, issue, pr, status, summary, next_steps, evidence, started_at, completed_at FROM runs"
+  if [[ -n "$where" ]]; then
+    sql="$sql WHERE $where"
+  fi
+  sql="$sql ORDER BY started_at_epoch DESC, id DESC LIMIT $LIMIT"
+  sqlite3 -line "$db" "$sql"
+}
+
+mem_write() {
+  local db now epoch open_id id completed_at completed_epoch
+  [[ -n "${RUN_LANE:-}" ]] || { echo "Need --lane <lane>" >&2; exit 1; }
+  case "${STATUS:-}" in
+    started|done|blocked|failed) ;;
+    *) echo "Need --status started|done|blocked|failed" >&2; exit 1 ;;
+  esac
+  HARNESS="${HARNESS:-$RUNNER}"
+  case "$HARNESS" in
+    claude|cursor|codex|grok) ;;
+    *) echo "Need --harness claude|cursor|codex|grok" >&2; exit 1 ;;
+  esac
+  detect_project
+  normalize_evidence
+  memory_init
+  db="$(memory_db)"
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  epoch="$(date +%s)"
+  open_id=""
+  if [[ "$STATUS" != "started" && -n "$ISSUE" ]]; then
+    open_id="$(sqlite3 "$db" "SELECT id FROM runs WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE") AND status = 'started' ORDER BY started_at_epoch DESC, id DESC LIMIT 1")"
+  fi
+  if [[ -n "$open_id" ]]; then
+    sqlite3 "$db" "UPDATE runs SET status = $(sql_quote "$STATUS"), summary = COALESCE($(sql_nullable "$SUMMARY"), summary), next_steps = COALESCE($(sql_nullable "$NEXT_STEPS"), next_steps), evidence = CASE WHEN $(sql_quote "$EVIDENCE") = '[]' THEN evidence ELSE $(sql_quote "$EVIDENCE") END, pr = COALESCE($(sql_nullable "$PR"), pr), completed_at = $(sql_quote "$now"), completed_at_epoch = $epoch WHERE id = $open_id"
+    echo "id=$open_id status=$STATUS"
+    return
+  fi
+  if [[ "$STATUS" == "started" ]]; then
+    completed_at="NULL"
+    completed_epoch="NULL"
+  else
+    completed_at="$(sql_quote "$now")"
+    completed_epoch="$epoch"
+  fi
+  id="$(sqlite3 "$db" "INSERT INTO runs (harness, lane, project, issue, pr, status, summary, next_steps, evidence, started_at, started_at_epoch, completed_at, completed_at_epoch) VALUES ($(sql_quote "$HARNESS"), $(sql_quote "$RUN_LANE"), $(sql_quote "$PROJECT"), $(sql_nullable "$ISSUE"), $(sql_nullable "$PR"), $(sql_quote "$STATUS"), $(sql_nullable "$SUMMARY"), $(sql_nullable "$NEXT_STEPS"), $(sql_quote "$EVIDENCE"), $(sql_quote "$now"), $epoch, $completed_at, $completed_epoch); SELECT last_insert_rowid();")"
+  echo "id=$id status=$STATUS"
+}
+
 case "$LANE" in
+  mem)
+    case "$MEM_CMD" in
+      read) mem_read ;;
+      write) mem_write ;;
+      *) usage ;;
+    esac
+    ;;
   feature|bug|docs)
     need_issue
     DIR="$(repo_dir)"

--- a/factory.sh
+++ b/factory.sh
@@ -41,13 +41,6 @@ LANE="${1:-}"
 [[ -n "$LANE" ]] || usage
 shift || usage
 MEM_CMD=""
-if [[ "$LANE" == "mem" ]]; then
-  MEM_CMD="${1:-}"
-  case "$MEM_CMD" in
-    read|write) shift ;;
-    *) usage ;;
-  esac
-fi
 REPO=""
 ISSUE=""
 PR=""
@@ -63,30 +56,45 @@ NEXT_STEPS=""
 EVIDENCE=""
 LIMIT=""
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --repo) REPO="${2:-}"; shift 2 ;;
-    --issue) ISSUE="${2:-}"; shift 2 ;;
-    --pr) PR="${2:-}"; shift 2 ;;
-    --url) URL="${2:-}"; shift 2 ;;
-    --owner) OWNER="${2:-}"; shift 2 ;;
-    --runner) RUNNER="${2:-}"; shift 2 ;;
-    --harness) HARNESS="${2:-}"; shift 2 ;;
-    --lane) RUN_LANE="${2:-}"; shift 2 ;;
-    --project) PROJECT="${2:-}"; shift 2 ;;
-    --status) STATUS="${2:-}"; shift 2 ;;
-    --summary) SUMMARY="${2:-}"; shift 2 ;;
-    --next-steps) NEXT_STEPS="${2:-}"; shift 2 ;;
-    --evidence) EVIDENCE="${2:-}"; shift 2 ;;
-    --limit) LIMIT="${2:-}"; shift 2 ;;
-    --question) QUESTION="${2:-}"; shift 2 ;;
-    --yes) YES=1; shift ;;
-    -h|--help) usage ;;
-    *) echo "Unknown arg: $1" >&2; usage ;;
+if [[ "$LANE" == "mem" ]]; then
+  MEM_CMD="${1:-}"
+  case "$MEM_CMD" in
+    read|write) shift ;;
+    *) usage ;;
   esac
-done
-
-if [[ "$LANE" != "mem" ]]; then
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --issue) ISSUE="${2:-}"; shift 2 ;;
+      --pr) PR="${2:-}"; shift 2 ;;
+      --owner) OWNER="${2:-}"; shift 2 ;;
+      --repo) REPO="${2:-}"; shift 2 ;;
+      --runner|--harness) HARNESS="${2:-}"; shift 2 ;;
+      --lane) RUN_LANE="${2:-}"; shift 2 ;;
+      --project) PROJECT="${2:-}"; shift 2 ;;
+      --status) STATUS="${2:-}"; shift 2 ;;
+      --summary) SUMMARY="${2:-}"; shift 2 ;;
+      --next-steps) NEXT_STEPS="${2:-}"; shift 2 ;;
+      --evidence) EVIDENCE="${2:-}"; shift 2 ;;
+      --limit) LIMIT="${2:-}"; shift 2 ;;
+      -h|--help) usage ;;
+      *) echo "Unknown arg: $1" >&2; usage ;;
+    esac
+  done
+else
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) REPO="${2:-}"; shift 2 ;;
+      --issue) ISSUE="${2:-}"; shift 2 ;;
+      --pr) PR="${2:-}"; shift 2 ;;
+      --url) URL="${2:-}"; shift 2 ;;
+      --owner) OWNER="${2:-}"; shift 2 ;;
+      --runner) RUNNER="${2:-}"; shift 2 ;;
+      --question) QUESTION="${2:-}"; shift 2 ;;
+      --yes) YES=1; shift ;;
+      -h|--help) usage ;;
+      *) echo "Unknown arg: $1" >&2; usage ;;
+    esac
+  done
   detect_runner
 fi
 
@@ -187,8 +195,9 @@ memory_init() {
   db="$(memory_db)"
   mkdir -p "$(dirname "$db")"
   need_sqlite
-  sqlite3 "$db" "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;" >/dev/null
-  sqlite3 "$db" <<'SQL'
+  sqlite3 "$db" >/dev/null <<'SQL'
+PRAGMA journal_mode=WAL;
+PRAGMA busy_timeout=5000;
 CREATE TABLE IF NOT EXISTS schema_versions (
   id INTEGER PRIMARY KEY,
   version INTEGER UNIQUE NOT NULL,
@@ -218,21 +227,113 @@ VALUES (1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'));
 SQL
 }
 
+sqlite_tx() {
+  local db="$1"
+  sqlite3 "$db" <<SQL
+.output /dev/null
+PRAGMA busy_timeout=5000;
+.output stdout
+BEGIN IMMEDIATE;
+$2
+COMMIT;
+SQL
+}
+
+owner_name() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]
+}
+
+project_from_remote() {
+  local raw="$1"
+  local project
+  [[ -n "$raw" ]] || { echo "Need --project owner/name" >&2; exit 1; }
+  if owner_name "$raw"; then
+    PROJECT="$raw"
+    return
+  fi
+  project="$(printf '%s' "$raw" | sed -E -e 's#^[a-zA-Z0-9+.-]+://##' -e 's#^.*@##' -e 's#^[^:/]+(:[0-9]+)?[:/]##' -e 's#\.git$##' -e 's#/$##')"
+  owner_name "$project" || { echo "Need --project owner/name" >&2; exit 1; }
+  PROJECT="$project"
+}
+
 detect_project() {
-  if [[ -n "${PROJECT:-}" ]]; then
-    return
+  if [[ -z "${PROJECT:-}" ]]; then
+    if [[ -n "$OWNER" && -n "$REPO" ]]; then
+      PROJECT="$OWNER/$REPO"
+    else
+      local url=""
+      url="$(git -C "$WORKSPACE" remote get-url origin 2>/dev/null || true)"
+      if [[ -z "$url" ]]; then
+        url="$(git remote get-url origin 2>/dev/null || true)"
+      fi
+      [[ -n "$url" ]] || { echo "Need --project owner/name" >&2; exit 1; }
+      PROJECT="$url"
+    fi
   fi
-  if [[ -n "$OWNER" && -n "$REPO" ]]; then
-    PROJECT="$OWNER/$REPO"
-    return
+  project_from_remote "$PROJECT"
+}
+
+looks_like_secret() {
+  local s="$1"
+  case "$s" in
+    *-----BEGIN*|*"BEGIN PEM"*|*ghp_*|*gho_*|*ghu_*|*ghs_*|*ghr_*|*github_pat_*|*xoxb-*|*xoxp-*|*xoxa-*|*xoxs-*|*sk-ant-*|*password=*|*token=*|*api_key=*|*secret=*) return 0 ;;
+  esac
+  if printf '%s' "$s" | grep -Eq 'AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9]{20,}'; then
+    return 0
   fi
-  local url=""
-  url="$(git -C "$WORKSPACE" remote get-url origin 2>/dev/null || true)"
-  if [[ -z "$url" ]]; then
-    url="$(git remote get-url origin 2>/dev/null || true)"
-  fi
-  [[ -n "$url" ]] || { echo "Need --project owner/name" >&2; exit 1; }
-  PROJECT="$(printf '%s' "$url" | sed -E -e 's#^[a-zA-Z0-9+.-]+://##' -e 's#^git@##' -e 's#^[^:/]+[:/]##' -e 's#\.git$##')"
+  return 1
+}
+
+is_url_or_path() {
+  local s="$1"
+  [[ -n "$s" ]] || return 1
+  case "$s" in
+    *$'\n'*|*$'\r'*|*' '*) return 1 ;;
+  esac
+  case "$s" in
+    http://*|https://*|/*|./*|../*|*/*) return 0 ;;
+  esac
+  return 1
+}
+
+validate_summary() {
+  [[ -n "${SUMMARY:-}" ]] || return 0
+  looks_like_secret "$SUMMARY" && { echo "Refusing secret in mem write" >&2; exit 1; }
+  [[ "$SUMMARY" != *$'\n'* && "$SUMMARY" != *$'\r'* ]] || { echo "Need one-sentence --summary" >&2; exit 1; }
+  [[ ${#SUMMARY} -le 200 ]] || { echo "Need one-sentence --summary" >&2; exit 1; }
+  case "$SUMMARY" in
+    *'. '*|*'? '*|*'! '*) echo "Need one-sentence --summary" >&2; exit 1 ;;
+  esac
+}
+
+validate_next_steps() {
+  [[ -n "${NEXT_STEPS:-}" ]] || return 0
+  looks_like_secret "$NEXT_STEPS" && { echo "Refusing secret in mem write" >&2; exit 1; }
+  [[ "$NEXT_STEPS" != *$'\n'* && "$NEXT_STEPS" != *$'\r'* ]] || { echo "Need one-line --next-steps" >&2; exit 1; }
+}
+
+validate_evidence_items() {
+  local remain="$1"
+  local item
+  remain="${remain#"${remain%%[![:space:]]*}"}"
+  remain="${remain%"${remain##*[![:space:]]}"}"
+  [[ -n "$remain" ]] || return 0
+  while [[ -n "$remain" ]]; do
+    remain="${remain#"${remain%%[![:space:]]*}"}"
+    [[ "$remain" == \"* ]] || { echo "Need --evidence URL or path" >&2; exit 1; }
+    remain="${remain#\"}"
+    [[ "$remain" == *\"* ]] || { echo "Need --evidence URL or path" >&2; exit 1; }
+    item="${remain%%\"*}"
+    remain="${remain#*\"}"
+    looks_like_secret "$item" && { echo "Refusing secret in mem write" >&2; exit 1; }
+    is_url_or_path "$item" || { echo "Need --evidence URL or path" >&2; exit 1; }
+    remain="${remain#"${remain%%[![:space:]]*}"}"
+    if [[ "$remain" == ,* ]]; then
+      remain="${remain#,}"
+      continue
+    fi
+    [[ -z "$remain" ]] || { echo "Need --evidence URL or path" >&2; exit 1; }
+  done
 }
 
 normalize_evidence() {
@@ -240,10 +341,26 @@ normalize_evidence() {
     EVIDENCE='[]'
     return
   fi
-  if [[ "$EVIDENCE" == \[* ]]; then
+  looks_like_secret "$EVIDENCE" && { echo "Refusing secret in mem write" >&2; exit 1; }
+  [[ "$EVIDENCE" != *$'\n'* && "$EVIDENCE" != *$'\r'* ]] || { echo "Need --evidence URL or path" >&2; exit 1; }
+  if [[ "$EVIDENCE" == "[]" ]]; then
     return
   fi
+  if [[ "$EVIDENCE" == \[* ]]; then
+    [[ "$EVIDENCE" == *\] ]] || { echo "Need --evidence URL or path" >&2; exit 1; }
+    local inner="${EVIDENCE#\[}"
+    inner="${inner%\]}"
+    validate_evidence_items "$inner"
+    return
+  fi
+  is_url_or_path "$EVIDENCE" || { echo "Need --evidence URL or path" >&2; exit 1; }
   EVIDENCE="[$(json_quote "$EVIDENCE")]"
+}
+
+validate_payload() {
+  validate_summary
+  validate_next_steps
+  normalize_evidence
 }
 
 mem_read() {
@@ -276,7 +393,7 @@ mem_read() {
 }
 
 mem_write() {
-  local db now epoch open_id id completed_at completed_epoch
+  local db now epoch id completed_at completed_epoch sql
   [[ -n "${RUN_LANE:-}" ]] || { echo "Need --lane <lane>" >&2; exit 1; }
   case "${STATUS:-}" in
     started|done|blocked|failed) ;;
@@ -288,28 +405,48 @@ mem_write() {
     *) echo "Need --harness claude|cursor|codex|grok" >&2; exit 1 ;;
   esac
   detect_project
-  normalize_evidence
+  validate_payload
   memory_init
   db="$(memory_db)"
   now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   epoch="$(date +%s)"
-  open_id=""
   if [[ "$STATUS" != "started" && -n "$ISSUE" ]]; then
-    open_id="$(sqlite3 "$db" "SELECT id FROM runs WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE") AND status = 'started' ORDER BY started_at_epoch DESC, id DESC LIMIT 1")"
-  fi
-  if [[ -n "$open_id" ]]; then
-    sqlite3 "$db" "UPDATE runs SET status = $(sql_quote "$STATUS"), summary = COALESCE($(sql_nullable "$SUMMARY"), summary), next_steps = COALESCE($(sql_nullable "$NEXT_STEPS"), next_steps), evidence = CASE WHEN $(sql_quote "$EVIDENCE") = '[]' THEN evidence ELSE $(sql_quote "$EVIDENCE") END, pr = COALESCE($(sql_nullable "$PR"), pr), completed_at = $(sql_quote "$now"), completed_at_epoch = $epoch WHERE id = $open_id"
-    echo "id=$open_id status=$STATUS"
-    return
-  fi
-  if [[ "$STATUS" == "started" ]]; then
-    completed_at="NULL"
-    completed_epoch="NULL"
+    sql="
+UPDATE runs SET
+  status = $(sql_quote "$STATUS"),
+  summary = COALESCE($(sql_nullable "$SUMMARY"), summary),
+  next_steps = COALESCE($(sql_nullable "$NEXT_STEPS"), next_steps),
+  evidence = CASE WHEN $(sql_quote "$EVIDENCE") = '[]' THEN evidence ELSE $(sql_quote "$EVIDENCE") END,
+  pr = COALESCE($(sql_nullable "$PR"), pr),
+  completed_at = $(sql_quote "$now"),
+  completed_at_epoch = $epoch
+WHERE id = (
+  SELECT id FROM runs
+  WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE") AND status = 'started'
+  ORDER BY started_at_epoch DESC, id DESC
+  LIMIT 1
+);
+INSERT INTO runs (harness, lane, project, issue, pr, status, summary, next_steps, evidence, started_at, started_at_epoch, completed_at, completed_at_epoch)
+SELECT $(sql_quote "$HARNESS"), $(sql_quote "$RUN_LANE"), $(sql_quote "$PROJECT"), $(sql_nullable "$ISSUE"), $(sql_nullable "$PR"), $(sql_quote "$STATUS"), $(sql_nullable "$SUMMARY"), $(sql_nullable "$NEXT_STEPS"), $(sql_quote "$EVIDENCE"), $(sql_quote "$now"), $epoch, $(sql_quote "$now"), $epoch
+WHERE changes() = 0;
+SELECT COALESCE(
+  (SELECT last_insert_rowid() WHERE last_insert_rowid() != 0 AND changes() != 0),
+  (SELECT id FROM runs WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE") AND completed_at_epoch = $epoch ORDER BY id DESC LIMIT 1)
+);"
   else
-    completed_at="$(sql_quote "$now")"
-    completed_epoch="$epoch"
+    if [[ "$STATUS" == "started" ]]; then
+      completed_at="NULL"
+      completed_epoch="NULL"
+    else
+      completed_at="$(sql_quote "$now")"
+      completed_epoch="$epoch"
+    fi
+    sql="
+INSERT INTO runs (harness, lane, project, issue, pr, status, summary, next_steps, evidence, started_at, started_at_epoch, completed_at, completed_at_epoch)
+VALUES ($(sql_quote "$HARNESS"), $(sql_quote "$RUN_LANE"), $(sql_quote "$PROJECT"), $(sql_nullable "$ISSUE"), $(sql_nullable "$PR"), $(sql_quote "$STATUS"), $(sql_nullable "$SUMMARY"), $(sql_nullable "$NEXT_STEPS"), $(sql_quote "$EVIDENCE"), $(sql_quote "$now"), $epoch, $completed_at, $completed_epoch);
+SELECT last_insert_rowid();"
   fi
-  id="$(sqlite3 "$db" "INSERT INTO runs (harness, lane, project, issue, pr, status, summary, next_steps, evidence, started_at, started_at_epoch, completed_at, completed_at_epoch) VALUES ($(sql_quote "$HARNESS"), $(sql_quote "$RUN_LANE"), $(sql_quote "$PROJECT"), $(sql_nullable "$ISSUE"), $(sql_nullable "$PR"), $(sql_quote "$STATUS"), $(sql_nullable "$SUMMARY"), $(sql_nullable "$NEXT_STEPS"), $(sql_quote "$EVIDENCE"), $(sql_quote "$now"), $epoch, $completed_at, $completed_epoch); SELECT last_insert_rowid();")"
+  id="$(sqlite_tx "$db" "$sql")"
   echo "id=$id status=$STATUS"
 }
 

--- a/tests/mem.sh
+++ b/tests/mem.sh
@@ -14,6 +14,41 @@ write() {
   "$FACTORY" mem write --harness grok --project test/repo "$@"
 }
 
+stored_project() {
+  sqlite3 "$FACTORY_MEMORY_DB" "SELECT project FROM runs ORDER BY id DESC LIMIT 1;"
+}
+
+write_from_origin() {
+  local url="$1"
+  local gitdir="$TMP/origin"
+  rm -rf "$gitdir"
+  mkdir -p "$gitdir"
+  git -C "$gitdir" init -q
+  git -C "$gitdir" remote add origin "$url"
+  unset FACTORY_OWNER
+  FACTORY_WORKSPACE="$gitdir" "$FACTORY" mem write --harness grok --lane feature --status started --issue 80 --summary "Detect project from origin" >"$TMP/pw"
+}
+
+reject_write() {
+  local why="$1"
+  shift
+  set +e
+  write "$@" >"$TMP/out" 2>"$TMP/err"
+  code=$?
+  set -e
+  [[ $code -ne 0 ]] || fail "should reject $why: $(cat "$TMP/out") $(cat "$TMP/err")"
+}
+
+reject_global() {
+  local flag="$1"
+  set +e
+  "$FACTORY" feature "$flag" x >"$TMP/out" 2>"$TMP/err"
+  code=$?
+  set -e
+  [[ $code -ne 0 ]] || fail "global parser accepted $flag"
+  grep -q "Unknown arg: $flag" "$TMP/err" || fail "global parser still accepts $flag: $(cat "$TMP/err")"
+}
+
 # Missing database: mem read warns and exits 0
 set +e
 "$FACTORY" mem read --issue 4 >"$TMP/out" 2>"$TMP/err"
@@ -55,7 +90,7 @@ count="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
 "$FACTORY" mem read --issue 4 >"$TMP/r2"
 grep -q "status = done" "$TMP/r2" || fail "read after done: $(cat "$TMP/r2")"
 grep -q "Opened the memory PR" "$TMP/r2" || fail "updated summary missing"
-grep -q "completed_at = 2" "$TMP/r2" || fail "completed_at should be set"
+grep -Eq "completed_at = 20[0-9]{2}-" "$TMP/r2" || fail "completed_at should be set"
 
 # done with no open run inserts
 write --lane feature --status done --issue 4 --summary "Second finish with no open run" >"$TMP/w3"
@@ -82,5 +117,131 @@ n="$(grep -c '^ *id = ' "$TMP/r5" || true)"
 "$FACTORY" mem read --issue 4 >"$TMP/r6"
 grep -q "other/repo" "$TMP/r6" && fail "--issue 4 should not include other/repo"
 grep -q "test/repo" "$TMP/r6" || fail "--issue 4 lost test/repo"
+
+write_from_origin "https://github.com/acme/widgets.git"
+[[ "$(stored_project)" == "acme/widgets" ]] || fail "https remote: $(stored_project)"
+
+write_from_origin "git@github.com:acme/widgets.git"
+[[ "$(stored_project)" == "acme/widgets" ]] || fail "git@ remote: $(stored_project)"
+
+write_from_origin "ssh://git@github.com/acme/widgets.git"
+[[ "$(stored_project)" == "acme/widgets" ]] || fail "ssh remote: $(stored_project)"
+
+write_from_origin "https://user:token@github.com/acme/widgets.git"
+[[ "$(stored_project)" == "acme/widgets" ]] || fail "credential remote stored $(stored_project)"
+[[ "$(stored_project)" != *token* ]] || fail "credential leaked in project"
+dump="$(sqlite3 "$FACTORY_MEMORY_DB" .dump)"
+printf '%s' "$dump" | grep -q "user:token" && fail "credential leaked into db dump"
+
+write --lane docs --status started --issue 81 --project "https://user:token@github.com/acme/widgets.git" --summary "Project flag is a remote url" >/dev/null
+[[ "$(stored_project)" == "acme/widgets" ]] || fail "--project url stored $(stored_project)"
+
+empty="$TMP/noremote"
+mkdir -p "$empty"
+set +e
+(
+  cd "$empty"
+  unset FACTORY_OWNER
+  unset FACTORY_WORKSPACE
+  "$FACTORY" mem write --harness grok --lane feature --status started --issue 80 --summary "No project"
+) >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -ne 0 ]] || fail "missing project should fail"
+grep -q "Need --project" "$TMP/err" || fail "missing project message: $(cat "$TMP/err")"
+
+reject_write "multi-sentence summary" --lane feature --status started --issue 90 --summary "First sentence. Second sentence."
+grep -q "one-sentence" "$TMP/err" || fail "multi-sentence message: $(cat "$TMP/err")"
+count="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE issue = '90';")"
+[[ "$count" == "0" ]] || fail "rejected write still persisted, count=$count"
+
+reject_write "newline summary" --lane feature --status started --issue 90 --summary $'Two\nlines'
+count="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE issue = '90';")"
+[[ "$count" == "0" ]] || fail "newline summary persisted"
+
+reject_write "prose evidence" --lane feature --status started --issue 90 --summary "Add a store" --evidence "dumped the response body here"
+grep -q "evidence" "$TMP/err" || fail "non path evidence message: $(cat "$TMP/err")"
+
+reject_write "secret evidence" --lane feature --status started --issue 90 --summary "Add a store" --evidence "password=supersecret"
+grep -qi "secret" "$TMP/err" || fail "secret evidence message: $(cat "$TMP/err")"
+
+pem="-----BEGIN"
+pem="${pem} PRIVATE KEY-----"
+reject_write "pem evidence" --lane feature --status started --issue 90 --summary "Add a store" --evidence "$pem"
+
+tok="ghp_"
+tok="${tok}notarealgithubtokenvalue"
+reject_write "token evidence" --lane feature --status started --issue 90 --summary "Add a store" --evidence "$tok"
+
+reject_write "secret summary" --lane feature --status started --issue 90 --summary "token=abc123"
+
+write --lane feature --status started --issue 91 --summary "It's a one-sentence summary" --evidence "/tmp/factory-evidence.txt" >"$TMP/q1"
+grep -q 'id=' "$TMP/q1" || fail "quoted summary should write"
+"$FACTORY" mem read --issue 91 >"$TMP/qr"
+grep -q "It's a one-sentence summary" "$TMP/qr" || fail "quoted summary round-trip: $(cat "$TMP/qr")"
+grep -q "/tmp/factory-evidence.txt" "$TMP/qr" || fail "path evidence missing"
+
+write --lane bug --status blocked --issue 92 --summary "Need a repro URL" --next-steps "Wait on telemetry" --evidence "https://example.com/repro" >"$TMP/b1"
+grep -q 'status=blocked' "$TMP/b1" || fail "blocked write: $(cat "$TMP/b1")"
+write --lane bug --status failed --issue 93 --summary "Tests did not pass" --evidence "./tests/mem.sh" >"$TMP/f1"
+grep -q 'status=failed' "$TMP/f1" || fail "failed write: $(cat "$TMP/f1")"
+"$FACTORY" mem read --issue 92 >"$TMP/br"
+grep -q "status = blocked" "$TMP/br" || fail "blocked read: $(cat "$TMP/br")"
+"$FACTORY" mem read --issue 93 >"$TMP/fr"
+grep -q "status = failed" "$TMP/fr" || fail "failed read: $(cat "$TMP/fr")"
+
+write --lane ci --status started --issue 40 --summary "Hold the db lock" >/dev/null
+rm -f "$TMP/locked"
+python3 -c "
+import sqlite3, time
+c = sqlite3.connect('$FACTORY_MEMORY_DB', isolation_level=None, timeout=5)
+c.execute('BEGIN EXCLUSIVE')
+open('$TMP/locked', 'w').write('1')
+time.sleep(1.2)
+c.execute('COMMIT')
+c.close()
+" &
+locker=$!
+i=0
+while [[ $i -lt 20 && ! -f "$TMP/locked" ]]; do
+  i=$((i + 1))
+  sleep 0.05
+done
+[[ -f "$TMP/locked" ]] || fail "lock holder did not start"
+set +e
+write --lane ci --status done --issue 40 --summary "Finish under lock" >"$TMP/lockout" 2>"$TMP/lockerr"
+lockcode=$?
+set -e
+wait "$locker" || true
+[[ $lockcode -eq 0 ]] || fail "finish while locked should wait, exit $lockcode err=$(cat "$TMP/lockerr")"
+grep -q 'status=done' "$TMP/lockout" || fail "finish under lock: $(cat "$TMP/lockout")"
+started="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE issue = '40' AND status = 'started';")"
+[[ "$started" == "0" ]] || fail "started row still open after finish, count=$started"
+
+reject_global --harness
+reject_global --status
+reject_global --summary
+reject_global --next-steps
+reject_global --evidence
+reject_global --limit
+reject_global --project
+reject_global --lane
+
+write --lane docs --status started --issue 41 --summary "Mem flags still parse" --harness grok >/dev/null
+"$FACTORY" mem read --issue 41 --limit 1 >"$TMP/mf"
+grep -q "lane = docs" "$TMP/mf" || fail "mem flags should still parse: $(cat "$TMP/mf")"
+
+hid="$TMP/nosqlite"
+mkdir -p "$hid"
+for cmd in bash mkdir date sed git grep dirname; do
+  src="$(command -v "$cmd" || true)"
+  [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
+done
+set +e
+PATH="$hid" "$FACTORY" mem write --harness grok --project test/repo --lane feature --status started --issue 42 --summary "Missing sqlite" >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -ne 0 ]] || fail "missing sqlite3 should fail"
+grep -q "sqlite3 not installed" "$TMP/err" || fail "missing sqlite3 message: $(cat "$TMP/err")"
 
 echo "ok mem"

--- a/tests/mem.sh
+++ b/tests/mem.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+write() {
+  "$FACTORY" mem write --harness grok --project test/repo "$@"
+}
+
+# Missing database: mem read warns and exits 0
+set +e
+"$FACTORY" mem read --issue 4 >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -eq 0 ]] || fail "missing db read exit $code"
+[[ ! -s "$TMP/out" ]] || fail "missing db read should be silent on stdout"
+grep -q "factory.db" "$TMP/err" || fail "missing db should warn with path"
+
+# Write creates dir, WAL, schema_versions, runs
+write --lane feature --status started --issue 4 --summary "Add the factory memory store" --next-steps "Read it back" --evidence "https://github.com/Kripu77/software-factory/issues/4" >"$TMP/w1"
+[[ -f "$FACTORY_MEMORY_DB" ]] || fail "write did not create db"
+grep -q 'id=1' "$TMP/w1" || fail "write should print id=1, got $(cat "$TMP/w1")"
+grep -q 'status=started' "$TMP/w1" || fail "write should print status=started"
+
+mode="$(sqlite3 "$FACTORY_MEMORY_DB" "PRAGMA journal_mode;")"
+[[ "$mode" == "wal" ]] || fail "journal_mode=$mode want wal"
+sqlite3 "$FACTORY_MEMORY_DB" "SELECT version FROM schema_versions WHERE version = 1;" | grep -q 1 || fail "schema_versions missing version 1"
+cols="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT sql FROM sqlite_master WHERE name = 'runs';")"
+printf '%s' "$cols" | grep -q "harness" || fail "runs table missing"
+
+# Round-trip read
+"$FACTORY" mem read --issue 4 >"$TMP/r1"
+grep -q "harness = grok" "$TMP/r1" || fail "read missing harness: $(cat "$TMP/r1")"
+grep -q "lane = feature" "$TMP/r1" || fail "read missing lane"
+grep -q "project = test/repo" "$TMP/r1" || fail "read missing project"
+grep -q "issue = 4" "$TMP/r1" || fail "read missing issue"
+grep -q "status = started" "$TMP/r1" || fail "read missing status"
+grep -q "Add the factory memory store" "$TMP/r1" || fail "read missing summary"
+grep -q "Read it back" "$TMP/r1" || fail "read missing next_steps"
+grep -q "software-factory/issues/4" "$TMP/r1" || fail "read missing evidence"
+
+# done updates the open run for issue+lane
+write --lane feature --status done --issue 4 --summary "Opened the memory PR" --next-steps "Review then CI" --evidence "https://github.com/Kripu77/software-factory/pull/99" >"$TMP/w2"
+grep -q 'id=1' "$TMP/w2" || fail "done should finish id=1, got $(cat "$TMP/w2")"
+grep -q 'status=done' "$TMP/w2" || fail "done should print status=done"
+count="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
+[[ "$count" == "1" ]] || fail "done should update not insert, count=$count"
+"$FACTORY" mem read --issue 4 >"$TMP/r2"
+grep -q "status = done" "$TMP/r2" || fail "read after done: $(cat "$TMP/r2")"
+grep -q "Opened the memory PR" "$TMP/r2" || fail "updated summary missing"
+grep -q "completed_at = 2" "$TMP/r2" || fail "completed_at should be set"
+
+# done with no open run inserts
+write --lane feature --status done --issue 4 --summary "Second finish with no open run" >"$TMP/w3"
+grep -q 'id=2' "$TMP/w3" || fail "no-open done should insert, got $(cat "$TMP/w3")"
+count="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
+[[ "$count" == "2" ]] || fail "expected 2 runs, count=$count"
+
+# newest first
+"$FACTORY" mem read --issue 4 >"$TMP/r3"
+awk '/^ *id = /{print $3; exit}' "$TMP/r3" | grep -q 2 || fail "newest id should be first: $(cat "$TMP/r3")"
+
+# --project filter, default limit 10
+i=0
+while [[ $i -lt 11 ]]; do
+  i=$((i + 1))
+  write --lane bug --status started --issue 7 --project other/repo --summary "other $i" >/dev/null
+done
+"$FACTORY" mem read --project other/repo >"$TMP/r4"
+n="$(grep -c '^ *id = ' "$TMP/r4" || true)"
+[[ "$n" == "10" ]] || fail "default limit 10, got $n"
+"$FACTORY" mem read --project other/repo --limit 2 >"$TMP/r5"
+n="$(grep -c '^ *id = ' "$TMP/r5" || true)"
+[[ "$n" == "2" ]] || fail "limit 2, got $n"
+"$FACTORY" mem read --issue 4 >"$TMP/r6"
+grep -q "other/repo" "$TMP/r6" && fail "--issue 4 should not include other/repo"
+grep -q "test/repo" "$TMP/r6" || fail "--issue 4 lost test/repo"
+
+echo "ok mem"


### PR DESCRIPTION
Adds factory.sh mem read and write against ~/.factory/memory/factory.db so this machine can remember lane runs without posting GitHub comments. started inserts a row. done, blocked, or failed finish the open issue+lane run, or insert if none is open. References Kripu77/software-factory#4.