### PR TITLE
Feat/5/bug-lane-reads-and-writes-factory-memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Use glossary terms from `CONTEXT.md`. Do not invent synonyms. Missing `CONTEXT.m
 - Tech lead: classify, quiz, ticket, dispatch one lane. Lanes report back. Dispatch the next. Do not implement.
 - Telemetry: evidence only. Report back to Tech lead. Do not implement. Do not classify.
 - Feature: do not expand the ask. Report back to Tech lead when the PR exists.
-- Bug: browser-repro if web, then TDD. Report back to Tech lead.
+- Bug: browser-repro if web, then TDD. Read factory memory at start. Write started, then done, blocked, or failed. Report back to Tech lead.
 - Docs: docs only. Report back to Tech lead.
 - Review: comments, not patches. Report the verdict back to Tech lead. Do not merge.
 - CI: checks until green. Report back to Tech lead. Do not merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Use glossary terms from `CONTEXT.md`. Do not invent synonyms. Missing `CONTEXT.m
 - Tech lead: classify, quiz, ticket, dispatch one lane. Lanes report back. Dispatch the next. Do not implement.
 - Telemetry: evidence only. Report back to Tech lead. Do not implement. Do not classify.
 - Feature: do not expand the ask. Report back to Tech lead when the PR exists.
-- Bug: browser-repro if web, then TDD. Read factory memory at start. Write started, then done, blocked, or failed. Report back to Tech lead.
+- Bug: browser-repro if web, then TDD. Read factory memory at start. Write started if none in progress, then done, blocked, or failed. Report back to Tech lead.
 - Docs: docs only. Report back to Tech lead.
 - Review: comments, not patches. Report the verdict back to Tech lead. Do not merge.
 - CI: checks until green. Report back to Tech lead. Do not merge.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Headless / CI still uses the script (never merges):
 ./factory.sh mem read --issue 12
 ```
 
-Lane runs on this machine are stored in `~/.factory/memory/factory.db`. Not git. GitHub comments stay the public ledger. `/bug` reads it at start and writes started, then done, blocked, or failed.
+Lane runs on this machine are stored in `~/.factory/memory/factory.db`. Not git. GitHub comments stay the public ledger. `/bug` reads it at start and writes started if none in progress, then done, blocked, or failed.
 
 ## Hard rules
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Headless / CI still uses the script (never merges):
 ./factory.sh mem read --issue 12
 ```
 
-Lane runs on this machine are stored in `~/.factory/memory/factory.db`. Not git. GitHub comments stay the public ledger.
+Lane runs on this machine are stored in `~/.factory/memory/factory.db`. Not git. GitHub comments stay the public ledger. `/bug` reads it at start and writes started, then done, blocked, or failed.
 
 ## Hard rules
 

--- a/commands/bug.md
+++ b/commands/bug.md
@@ -5,6 +5,6 @@ description: Reproduce then TDD-fix a ready-for-agent bug ticket in this checkou
 
 Read `lanes/bug.md` and `AGENTS.md`. Ask Telemetry for evidence if the ticket has none. Web app bugs: /browser-use first, then /tdd.
 
-At start, factory.sh mem read for this issue (or project if no issue). Near the beginning, factory.sh mem write --lane bug --status started. At the end, factory.sh mem write --lane bug --status done, blocked, or failed from the outcome. Missing memory: warn once and continue.
+At start, factory.sh mem read for this issue (or project if no issue). Write started only if that read shows no in-progress bug run: factory.sh mem write --lane bug --status started --harness <claude|cursor|codex|grok> --issue <n>. At the end, factory.sh mem write --lane bug --status done|blocked|failed --harness <claude|cursor|codex|grok> --issue <n> --summary "<one sentence>" --evidence <url-or-path> --next-steps "<what should happen next>". Missing memory: warn once and continue.
 
 Need a GitHub issue. New branch off main. Open a PR. Print the URL. Do not merge.

--- a/commands/bug.md
+++ b/commands/bug.md
@@ -5,4 +5,6 @@ description: Reproduce then TDD-fix a ready-for-agent bug ticket in this checkou
 
 Read `lanes/bug.md` and `AGENTS.md`. Ask Telemetry for evidence if the ticket has none. Web app bugs: /browser-use first, then /tdd.
 
+At start, factory.sh mem read for this issue (or project if no issue). Near the beginning, factory.sh mem write --lane bug --status started. At the end, factory.sh mem write --lane bug --status done, blocked, or failed from the outcome. Missing memory: warn once and continue.
+
 Need a GitHub issue. New branch off main. Open a PR. Print the URL. Do not merge.

--- a/factory.sh
+++ b/factory.sh
@@ -462,6 +462,7 @@ warn_mem() {
 
 bug_mem_write() {
   local status="$1" err code
+  shift
   err="$(mktemp)"
   set +e
   "$FACTORY/factory.sh" mem write \
@@ -471,6 +472,7 @@ bug_mem_write() {
     --issue "$ISSUE" \
     ${OWNER:+--owner "$OWNER"} \
     ${REPO:+--repo "$REPO"} \
+    "$@" \
     >/dev/null 2>"$err"
   code=$?
   set -e
@@ -493,24 +495,53 @@ bug_mem_start() {
     warn_mem "$(cat "$err")"
   fi
   rm -f "$err"
-  bug_mem_write started
+}
+
+bug_latest_status() {
+  local rec_lane="" rec_st=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      *"lane = "*) rec_lane="${line##* = }" ;;
+      *"status = "*) rec_st="${line##* = }" ;;
+      "")
+        if [[ "$rec_lane" == "bug" ]]; then
+          printf '%s\n' "$rec_st"
+          return 0
+        fi
+        rec_lane=""
+        rec_st=""
+        ;;
+    esac
+  done
+  if [[ "$rec_lane" == "bug" ]]; then
+    printf '%s\n' "$rec_st"
+  fi
 }
 
 bug_mem_finish() {
-  local code="$1" db open status
-  db="$(memory_db)"
-  [[ -f "$db" ]] || return 0
-  command -v sqlite3 >/dev/null 2>&1 || return 0
+  local code="$1" status latest err rec_status
+  err="$(mktemp)"
   set +e
-  open="$(sqlite3 "$db" "SELECT COUNT(*) FROM runs WHERE issue = $(sql_quote "$ISSUE") AND lane = 'bug' AND status = 'started';")"
+  latest="$("$FACTORY/factory.sh" mem read --issue "$ISSUE" 2>"$err")"
   set -e
-  [[ "${open:-0}" -gt 0 ]] || return 0
+  if [[ -s "$err" ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
+  rec_status="$(printf '%s\n' "$latest" | bug_latest_status)"
+  case "$rec_status" in
+    blocked|done|failed) return 0 ;;
+  esac
   if [[ "$code" -eq 0 ]]; then
     status=done
   else
     status=failed
   fi
-  bug_mem_write "$status"
+  local extra=(--summary "Bug lane ${status}." --next-steps "Tech lead dispatches the next lane.")
+  if [[ -n "$OWNER" && -n "$REPO" && -n "$ISSUE" ]]; then
+    extra+=(--evidence "https://github.com/${OWNER}/${REPO}/issues/${ISSUE}")
+  fi
+  bug_mem_write "$status" "${extra[@]}"
 }
 
 case "$LANE" in
@@ -531,6 +562,7 @@ case "$LANE" in
     DIR="$(repo_dir)"
     bug_mem_start
     prompt="Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
+    prompt+=$'\n'"Memory writes: factory.sh mem write --lane bug --harness $RUNNER --issue $ISSUE --summary '<one sentence>' --evidence <url-or-path> --next-steps '<next>'."
     if [[ -n "${MEM_CONTEXT:-}" ]]; then
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
     fi

--- a/factory.sh
+++ b/factory.sh
@@ -450,6 +450,69 @@ SELECT last_insert_rowid();"
   echo "id=$id status=$STATUS"
 }
 
+MEM_WARNED=0
+MEM_CONTEXT=""
+
+warn_mem() {
+  [[ "${MEM_WARNED}" -eq 0 ]] || return 0
+  MEM_WARNED=1
+  [[ -n "${1:-}" ]] || return 0
+  printf '%s\n' "$1" >&2
+}
+
+bug_mem_write() {
+  local status="$1" err code
+  err="$(mktemp)"
+  set +e
+  "$FACTORY/factory.sh" mem write \
+    --lane bug \
+    --status "$status" \
+    --harness "$RUNNER" \
+    --issue "$ISSUE" \
+    ${OWNER:+--owner "$OWNER"} \
+    ${REPO:+--repo "$REPO"} \
+    >/dev/null 2>"$err"
+  code=$?
+  set -e
+  if [[ $code -ne 0 ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
+}
+
+bug_mem_start() {
+  local err code
+  MEM_WARNED=0
+  MEM_CONTEXT=""
+  err="$(mktemp)"
+  set +e
+  MEM_CONTEXT="$("$FACTORY/factory.sh" mem read --issue "$ISSUE" 2>"$err")"
+  code=$?
+  set -e
+  if [[ $code -ne 0 || -s "$err" ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
+  bug_mem_write started
+}
+
+bug_mem_finish() {
+  local code="$1" db open status
+  db="$(memory_db)"
+  [[ -f "$db" ]] || return 0
+  command -v sqlite3 >/dev/null 2>&1 || return 0
+  set +e
+  open="$(sqlite3 "$db" "SELECT COUNT(*) FROM runs WHERE issue = $(sql_quote "$ISSUE") AND lane = 'bug' AND status = 'started';")"
+  set -e
+  [[ "${open:-0}" -gt 0 ]] || return 0
+  if [[ "$code" -eq 0 ]]; then
+    status=done
+  else
+    status=failed
+  fi
+  bug_mem_write "$status"
+}
+
 case "$LANE" in
   mem)
     case "$MEM_CMD" in
@@ -458,10 +521,25 @@ case "$LANE" in
       *) usage ;;
     esac
     ;;
-  feature|bug|docs)
+  feature|docs)
     need_issue
     DIR="$(repo_dir)"
     run_agent "$DIR" "$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD"       "Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
+    ;;
+  bug)
+    need_issue
+    DIR="$(repo_dir)"
+    bug_mem_start
+    prompt="Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
+    if [[ -n "${MEM_CONTEXT:-}" ]]; then
+      prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
+    fi
+    set +e
+    run_agent "$DIR" "$(cat "$FACTORY/lanes/bug.md")"$'\n'"$HARD" "$prompt"
+    code=$?
+    set -e
+    bug_mem_finish "$code"
+    exit "$code"
     ;;
   review)
     need_pr

--- a/lanes/bug.md
+++ b/lanes/bug.md
@@ -1,9 +1,14 @@
 You are the factory Bug lane.
 
+At start, run factory.sh mem read for this issue (or project if no issue) and put those rows in context.
+Near the beginning, run factory.sh mem write --lane bug --status started --harness <this harness>.
+If memory is missing, warn once and continue. Memory never blocks the lane.
+
 Ask Telemetry for evidence if it is not already in the ticket.
 If this is a web application bug, reproduce it in a real browser with /browser-use before you write a test. Screenshot the failure. If login is required, hand that step to a human. Never read .env.
 If there is no browser, say so and fall back to ticket steps plus a failing test.
 Then TDD fix. Follow /tdd, /implement, /unslop.
 Work only on the ticket in this prompt. New branch off main.
 Never merge. Never touch other PRs.
-When your job is done, report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, run factory.sh mem write --lane bug --status done, blocked, or failed from the outcome. Same payload as the report-back: one-sentence summary, issue or PR URL, evidence URLs or paths only, what should happen next. No secrets. project is owner/name only.
+Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/bug.md
+++ b/lanes/bug.md
@@ -1,8 +1,6 @@
 You are the factory Bug lane.
 
-At start, run factory.sh mem read for this issue (or project if no issue) and put those rows in context.
-Near the beginning, run factory.sh mem write --lane bug --status started --harness <this harness>.
-If memory is missing, warn once and continue. Memory never blocks the lane.
+At start, factory.sh mem read for this issue. Write started only if that read shows no in-progress bug run. Missing memory: warn once and continue.
 
 Ask Telemetry for evidence if it is not already in the ticket.
 If this is a web application bug, reproduce it in a real browser with /browser-use before you write a test. Screenshot the failure. If login is required, hand that step to a human. Never read .env.
@@ -10,5 +8,4 @@ If there is no browser, say so and fall back to ticket steps plus a failing test
 Then TDD fix. Follow /tdd, /implement, /unslop.
 Work only on the ticket in this prompt. New branch off main.
 Never merge. Never touch other PRs.
-When your job is done, run factory.sh mem write --lane bug --status done, blocked, or failed from the outcome. Same payload as the report-back: one-sentence summary, issue or PR URL, evidence URLs or paths only, what should happen next. No secrets. project is owner/name only.
-Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/tests/bug.sh
+++ b/tests/bug.sh
@@ -12,7 +12,22 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 
 need_text() {
   local file="$1" pat="$2"
-  grep -q "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+  grep -q -- "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+}
+
+bytes_under() {
+  local file="$1" max="$2" n
+  n="$(wc -c < "$ROOT/$file" | tr -d ' ')"
+  [[ "$n" -lt "$max" ]] || fail "$file is $n bytes, stay under $max"
+}
+
+fn_body() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\)" {on=1}
+    on {print}
+    on && /^}$/ {exit}
+  ' "$ROOT/factory.sh"
 }
 
 WS="$TMP/workspace"
@@ -36,9 +51,14 @@ done
 : > "$dump/ran"
 if command -v sqlite3 >/dev/null 2>&1 && [[ -f "${FACTORY_MEMORY_DB:-}" ]]; then
   sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE lane = 'bug' ORDER BY id DESC LIMIT 1;" > "$dump/status-at-start" || true
+else
+  : > "$dump/status-at-start"
+fi
+if [[ -n "${GROK_MEM_START:-}" ]]; then
+  "${FACTORY_SH:?}" mem write --lane bug --status started --harness grok --issue 5 --project acme/widgets >/dev/null
 fi
 if [[ -n "${GROK_MEM_STATUS:-}" ]]; then
-  "${FACTORY_SH:?}" mem write --lane bug --status "$GROK_MEM_STATUS" --harness grok --issue 5 --project acme/widgets --summary "${GROK_SUMMARY:-Lane finished}" --evidence "${GROK_EVIDENCE:-https://github.com/acme/widgets/issues/5}" >/dev/null
+  "${FACTORY_SH:?}" mem write --lane bug --status "$GROK_MEM_STATUS" --harness grok --issue 5 --project acme/widgets --summary "${GROK_SUMMARY:-Lane finished}" --evidence "${GROK_EVIDENCE:-https://github.com/acme/widgets/issues/5}" --next-steps "${GROK_NEXT:-Tech lead dispatches the next lane}" >/dev/null
 fi
 exit "${GROK_EXIT:-0}"
 EOF
@@ -62,6 +82,14 @@ count_runs() {
   sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE issue = '5' AND lane = 'bug';"
 }
 
+count_status() {
+  sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE issue = '5' AND lane = 'bug' AND status = '$1';"
+}
+
+field_for() {
+  sqlite3 "$FACTORY_MEMORY_DB" "SELECT $1 FROM runs WHERE issue = '5' AND lane = 'bug' ORDER BY id DESC LIMIT 1;"
+}
+
 # Lane and /bug command wire mem read/write
 need_text lanes/bug.md "mem read"
 need_text lanes/bug.md "mem write"
@@ -72,6 +100,7 @@ need_text lanes/bug.md "failed"
 need_text lanes/bug.md "warn once"
 need_text lanes/bug.md "Tech lead"
 need_text lanes/bug.md "Do not dispatch"
+need_text lanes/bug.md "in-progress"
 need_text commands/bug.md "mem read"
 need_text commands/bug.md "mem write"
 need_text commands/bug.md "started"
@@ -79,8 +108,20 @@ need_text commands/bug.md "done"
 need_text commands/bug.md "blocked"
 need_text commands/bug.md "failed"
 need_text commands/bug.md "warn once"
+need_text commands/bug.md "in-progress"
+need_text commands/bug.md "--harness"
+need_text commands/bug.md "--summary"
+need_text commands/bug.md "--evidence"
+need_text commands/bug.md "--next-steps"
+bytes_under lanes/bug.md 1000
+bytes_under commands/bug.md 1000
+grep -q -- "--summary" "$ROOT/lanes/bug.md" && fail "put mem flags in /bug or the injected prompt, not a second dump in the lane"
 
-# Missing DB: warn once, lane still succeeds, started is written
+fn_body bug_mem_start | grep -Eq 'bug_mem_write started|--status started' && fail "wrapper must not write started"
+fn_body bug_mem_finish | grep -q sqlite3 && fail "bug_mem_finish must not call sqlite3"
+fn_body bug_mem_finish | grep -q "mem read\|bug_mem_write\|mem write" || fail "bug_mem_finish must go through factory.sh mem"
+
+# Missing DB: warn once, lane still succeeds, finish records done
 rm -rf "$DUMP" "$TMP/memory"
 mkdir -p "$DUMP"
 set +e
@@ -91,9 +132,12 @@ set -e
 [[ -f "$DUMP/ran" ]] || fail "missing db should still run the bug lane"
 warns="$(grep -c "factory.db\|factory memory" "$TMP/err" || true)"
 [[ "$warns" == "1" ]] || fail "missing db should warn once, got $warns: $(cat "$TMP/err")"
-[[ -f "$FACTORY_MEMORY_DB" ]] || fail "started write should create db"
+[[ -f "$FACTORY_MEMORY_DB" ]] || fail "finish write should create db"
 [[ "$(status_for)" == "done" ]] || fail "successful lane should finish done, got $(status_for)"
-[[ "$(cat "$DUMP/status-at-start")" == "started" ]] || fail "started should be written before the runner: $(cat "$DUMP/status-at-start")"
+[[ ! -s "$DUMP/status-at-start" ]] || fail "wrapper should not write started before the runner: $(cat "$DUMP/status-at-start")"
+[[ -n "$(field_for summary)" ]] || fail "terminal done missing summary"
+[[ "$(field_for evidence)" != "[]" ]] || fail "terminal done missing evidence"
+[[ -n "$(field_for next_steps)" ]] || fail "terminal done missing next_steps"
 
 # Second run sees the first in context
 rm -rf "$DUMP"
@@ -102,12 +146,14 @@ run_bug >"$TMP/out2" 2>"$TMP/err2"
 grep -q "acme/widgets" "$DUMP/prompt" || fail "second run should see prior memory: $(cat "$DUMP/prompt")"
 grep -q "status = done" "$DUMP/prompt" || fail "second run should see first run status: $(cat "$DUMP/prompt")"
 
-# Agent can write blocked; factory does not overwrite with done
+# Fake runner writes started then blocked; one row, blocked, no extra done
 rm -rf "$DUMP" "$TMP/memory"
 mkdir -p "$DUMP"
-GROK_MEM_STATUS=blocked GROK_SUMMARY="Need a human login" run_bug >"$TMP/bout" 2>"$TMP/berr"
+GROK_MEM_START=1 GROK_MEM_STATUS=blocked GROK_SUMMARY="Need a human login" run_bug >"$TMP/bout" 2>"$TMP/berr"
 [[ "$(status_for)" == "blocked" ]] || fail "blocked outcome should stick, got $(status_for)"
-[[ "$(count_runs)" == "1" ]] || fail "blocked should finish the started row, count=$(count_runs)"
+[[ "$(count_runs)" == "1" ]] || fail "started then blocked should be one row, count=$(count_runs)"
+[[ "$(count_status done)" == "0" ]] || fail "finish must not clobber blocked with done"
+[[ "$(field_for summary)" == "Need a human login" ]] || fail "blocked summary overwritten: $(field_for summary)"
 
 # Agent can write failed
 rm -rf "$DUMP" "$TMP/memory"
@@ -118,6 +164,7 @@ fcode=$?
 set -e
 [[ $fcode -ne 0 ]] || fail "failed runner should fail the lane"
 [[ "$(status_for)" == "failed" ]] || fail "failed outcome should stick, got $(status_for)"
+[[ "$(count_runs)" == "1" ]] || fail "failed should be one row, count=$(count_runs)"
 
 # sqlite3 missing: warn once, lane still succeeds
 hid="$TMP/nosqlite"

--- a/tests/bug.sh
+++ b/tests/bug.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+need_text() {
+  local file="$1" pat="$2"
+  grep -q "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+}
+
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
+DUMP="$TMP/dump"
+mkdir -p "$DUMP" "$TMP/bin"
+
+cat > "$TMP/bin/grok" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p) printf '%s\n' "$2" > "$dump/prompt"; shift 2 ;;
+    --rules) printf '%s\n' "$2" > "$dump/rules"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+: > "$dump/ran"
+if command -v sqlite3 >/dev/null 2>&1 && [[ -f "${FACTORY_MEMORY_DB:-}" ]]; then
+  sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE lane = 'bug' ORDER BY id DESC LIMIT 1;" > "$dump/status-at-start" || true
+fi
+if [[ -n "${GROK_MEM_STATUS:-}" ]]; then
+  "${FACTORY_SH:?}" mem write --lane bug --status "$GROK_MEM_STATUS" --harness grok --issue 5 --project acme/widgets --summary "${GROK_SUMMARY:-Lane finished}" --evidence "${GROK_EVIDENCE:-https://github.com/acme/widgets/issues/5}" >/dev/null
+fi
+exit "${GROK_EXIT:-0}"
+EOF
+chmod +x "$TMP/bin/grok"
+
+run_bug() {
+  PATH="$TMP/bin:$PATH" \
+    FAKE_DUMP="$DUMP" \
+    FACTORY_SH="$FACTORY" \
+    FACTORY_WORKSPACE="$WS" \
+    FACTORY_OWNER=acme \
+    FACTORY_RUNNER=grok \
+    "$FACTORY" bug --repo widgets --issue 5
+}
+
+status_for() {
+  sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE issue = '5' AND lane = 'bug' ORDER BY id DESC LIMIT 1;"
+}
+
+count_runs() {
+  sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE issue = '5' AND lane = 'bug';"
+}
+
+# Lane and /bug command wire mem read/write
+need_text lanes/bug.md "mem read"
+need_text lanes/bug.md "mem write"
+need_text lanes/bug.md "started"
+need_text lanes/bug.md "done"
+need_text lanes/bug.md "blocked"
+need_text lanes/bug.md "failed"
+need_text lanes/bug.md "warn once"
+need_text lanes/bug.md "Tech lead"
+need_text lanes/bug.md "Do not dispatch"
+need_text commands/bug.md "mem read"
+need_text commands/bug.md "mem write"
+need_text commands/bug.md "started"
+need_text commands/bug.md "done"
+need_text commands/bug.md "blocked"
+need_text commands/bug.md "failed"
+need_text commands/bug.md "warn once"
+
+# Missing DB: warn once, lane still succeeds, started is written
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+set +e
+run_bug >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -eq 0 ]] || fail "missing db bug lane exit $code err=$(cat "$TMP/err")"
+[[ -f "$DUMP/ran" ]] || fail "missing db should still run the bug lane"
+warns="$(grep -c "factory.db\|factory memory" "$TMP/err" || true)"
+[[ "$warns" == "1" ]] || fail "missing db should warn once, got $warns: $(cat "$TMP/err")"
+[[ -f "$FACTORY_MEMORY_DB" ]] || fail "started write should create db"
+[[ "$(status_for)" == "done" ]] || fail "successful lane should finish done, got $(status_for)"
+[[ "$(cat "$DUMP/status-at-start")" == "started" ]] || fail "started should be written before the runner: $(cat "$DUMP/status-at-start")"
+
+# Second run sees the first in context
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+run_bug >"$TMP/out2" 2>"$TMP/err2"
+grep -q "acme/widgets" "$DUMP/prompt" || fail "second run should see prior memory: $(cat "$DUMP/prompt")"
+grep -q "status = done" "$DUMP/prompt" || fail "second run should see first run status: $(cat "$DUMP/prompt")"
+
+# Agent can write blocked; factory does not overwrite with done
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+GROK_MEM_STATUS=blocked GROK_SUMMARY="Need a human login" run_bug >"$TMP/bout" 2>"$TMP/berr"
+[[ "$(status_for)" == "blocked" ]] || fail "blocked outcome should stick, got $(status_for)"
+[[ "$(count_runs)" == "1" ]] || fail "blocked should finish the started row, count=$(count_runs)"
+
+# Agent can write failed
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+set +e
+GROK_MEM_STATUS=failed GROK_SUMMARY="Tests did not pass" GROK_EXIT=1 run_bug >"$TMP/fout" 2>"$TMP/ferr"
+fcode=$?
+set -e
+[[ $fcode -ne 0 ]] || fail "failed runner should fail the lane"
+[[ "$(status_for)" == "failed" ]] || fail "failed outcome should stick, got $(status_for)"
+
+# sqlite3 missing: warn once, lane still succeeds
+hid="$TMP/nosqlite"
+mkdir -p "$hid"
+for cmd in bash mkdir date sed git grep dirname cat rm mktemp printf; do
+  src="$(command -v "$cmd" || true)"
+  [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
+done
+cp "$TMP/bin/grok" "$hid/grok"
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+set +e
+PATH="$hid" FAKE_DUMP="$DUMP" FACTORY_SH="$FACTORY" FACTORY_WORKSPACE="$WS" FACTORY_OWNER=acme FACTORY_RUNNER=grok \
+  "$FACTORY" bug --repo widgets --issue 5 >"$TMP/nout" 2>"$TMP/nerr"
+ncode=$?
+set -e
+[[ $ncode -eq 0 ]] || fail "missing sqlite3 should not fail the lane, exit $ncode err=$(cat "$TMP/nerr")"
+[[ -f "$DUMP/ran" ]] || fail "missing sqlite3 should still run the bug lane"
+nwarns="$(grep -c "factory.db\|factory memory\|sqlite3" "$TMP/nerr" || true)"
+[[ "$nwarns" == "1" ]] || fail "missing sqlite3 should warn once, got $nwarns: $(cat "$TMP/nerr")"
+
+echo "ok bug"


### PR DESCRIPTION
The bug lane and /bug now read factory memory at start and write started, then done, blocked, or failed from the outcome. If the database is missing they warn once and keep going. Reports still go to Tech lead; we do not dispatch the next lane. References Kripu77/software-factory#5.