### PR TITLE
Feat/7/tech lead reads factory memory

### DIFF
--- a/commands/lead.md
+++ b/commands/lead.md
@@ -4,3 +4,5 @@ description: Tech lead: classify, quiz, ticket on the owning repo, dispatch. Do 
 ---
 
 Read `lanes/tech-lead.md` and `AGENTS.md`. Follow /to-tickets. Ask Telemetry when production data exists. Do not implement. Do not merge.
+
+At start, factory.sh mem read for this issue (or project if no issue). Empty memory is fine. Memory is a hint. GitHub is the source of truth when this laptop has no rows.

--- a/factory.sh
+++ b/factory.sh
@@ -450,6 +450,35 @@ SELECT last_insert_rowid();"
   echo "id=$id status=$STATUS"
 }
 
+MEM_CONTEXT=""
+MEM_WARNED=0
+
+warn_mem() {
+  [[ "${MEM_WARNED}" -eq 0 ]] || return 0
+  MEM_WARNED=1
+  [[ -n "${1:-}" ]] || return 0
+  printf '%s\n' "$1" >&2
+}
+
+lead_mem_read() {
+  local err code args=()
+  MEM_WARNED=0
+  MEM_CONTEXT=""
+  err="$(mktemp)"
+  args+=(--issue "$ISSUE")
+  if [[ -n "${OWNER:-}" && -n "${REPO:-}" ]]; then
+    args+=(--project "$OWNER/$REPO")
+  fi
+  set +e
+  MEM_CONTEXT="$("$FACTORY/factory.sh" mem read "${args[@]}" 2>"$err")"
+  code=$?
+  set -e
+  if [[ $code -ne 0 || -s "$err" ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
+}
+
 case "$LANE" in
   mem)
     case "$MEM_CMD" in
@@ -492,7 +521,12 @@ case "$LANE" in
     ;;
   lead|tech-lead|cto)
     need_issue
-    run_agent "$WORKSPACE" "$(cat "$FACTORY/lanes/tech-lead.md")"$'\n'"$HARD"       "Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}."
+    lead_mem_read
+    prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}."
+    if [[ -n "${MEM_CONTEXT:-}" ]]; then
+      prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
+    fi
+    run_agent "$WORKSPACE" "$(cat "$FACTORY/lanes/tech-lead.md")"$'\n'"$HARD" "$prompt"
     ;;
   telemetry)
     need_question

--- a/factory.sh
+++ b/factory.sh
@@ -497,25 +497,6 @@ bug_mem_start() {
   rm -f "$err"
 }
 
-lead_mem_read() {
-  local err code args=()
-  MEM_WARNED=0
-  MEM_CONTEXT=""
-  err="$(mktemp)"
-  args+=(--issue "$ISSUE")
-  if [[ -n "${OWNER:-}" && -n "${REPO:-}" ]]; then
-    args+=(--project "$OWNER/$REPO")
-  fi
-  set +e
-  MEM_CONTEXT="$("$FACTORY/factory.sh" mem read "${args[@]}" 2>"$err")"
-  code=$?
-  set -e
-  if [[ $code -ne 0 || -s "$err" ]]; then
-    warn_mem "$(cat "$err")"
-  fi
-  rm -f "$err"
-}
-
 bug_latest_status() {
   local rec_lane="" rec_st=""
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -621,7 +602,7 @@ case "$LANE" in
     ;;
   lead|tech-lead|cto)
     need_issue
-    lead_mem_read
+    bug_mem_start
     prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}."
     if [[ -n "${MEM_CONTEXT:-}" ]]; then
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"

--- a/lanes/tech-lead.md
+++ b/lanes/tech-lead.md
@@ -1,5 +1,7 @@
 You are the factory Tech lead.
 
+Before classifying or dispatching, run factory.sh mem read for this issue (or project if no issue) and put those rows in context. Empty memory is fine. GitHub is the source of truth when this laptop has no rows. Memory is a hint, not a lock.
+
 Classify as bug, feature, or docs. Quiz the human on tracer-bullet slices, then publish GitHub issues on the owning repo with ready-for-agent. Dispatch one lane. Do not implement. Do not merge.
 
 Ask Telemetry for evidence before a Bug dispatch when production data exists.

--- a/tests/lead.sh
+++ b/tests/lead.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+need_text() {
+  local file="$1" pat="$2"
+  grep -q "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+}
+
+DUMP="$TMP/dump"
+mkdir -p "$DUMP" "$TMP/bin" "$TMP/workspace"
+
+cat > "$TMP/bin/grok" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p) printf '%s\n' "$2" > "$dump/prompt"; shift 2 ;;
+    --rules) printf '%s\n' "$2" > "$dump/rules"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+: > "$dump/ran"
+EOF
+chmod +x "$TMP/bin/grok"
+
+run_lead() {
+  PATH="$TMP/bin:$PATH" \
+    FAKE_DUMP="$DUMP" \
+    FACTORY_WORKSPACE="$TMP/workspace" \
+    FACTORY_OWNER=acme \
+    FACTORY_RUNNER=grok \
+    "$FACTORY" lead --issue 7 --repo widgets
+}
+
+# Lane and /lead command read memory, still dispatch, still do not implement
+need_text lanes/tech-lead.md "mem read"
+need_text lanes/tech-lead.md "hint"
+need_text lanes/tech-lead.md "Do not implement"
+need_text lanes/tech-lead.md "Dispatch"
+need_text lanes/tech-lead.md "Do not let a lane chain"
+need_text commands/lead.md "mem read"
+need_text commands/lead.md "Do not implement"
+
+# Missing DB: warn once, lead still runs, no write
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+set +e
+run_lead >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -eq 0 ]] || fail "missing db lead exit $code err=$(cat "$TMP/err")"
+[[ -f "$DUMP/ran" ]] || fail "missing db should still run lead"
+warns="$(grep -c "factory.db\|factory memory" "$TMP/err" || true)"
+[[ "$warns" == "1" ]] || fail "missing db should warn once, got $warns: $(cat "$TMP/err")"
+[[ ! -f "$FACTORY_MEMORY_DB" ]] || fail "lead must not create memory on read"
+
+# Rows for the issue are in the prompt. Lead does not write a run.
+"$FACTORY" mem write --harness grok --project acme/widgets --lane feature --status done --issue 7 --pr 40 --summary "Add widgets list" --next-steps "QA the PR" --evidence "https://github.com/acme/widgets/pull/40" >/dev/null
+before="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+run_lead >"$TMP/out2" 2>"$TMP/err2"
+[[ -f "$DUMP/ran" ]] || fail "lead with rows should run"
+grep -q "acme/widgets" "$DUMP/prompt" || fail "lead prompt missing project: $(cat "$DUMP/prompt")"
+grep -q "status = done" "$DUMP/prompt" || fail "lead prompt missing status: $(cat "$DUMP/prompt")"
+grep -q "Add widgets list" "$DUMP/prompt" || fail "lead prompt missing summary: $(cat "$DUMP/prompt")"
+grep -q "QA the PR" "$DUMP/prompt" || fail "lead prompt missing next_steps: $(cat "$DUMP/prompt")"
+after="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
+[[ "$before" == "$after" ]] || fail "lead must not write runs, before=$before after=$after"
+
+# sqlite3 missing: warn once, lead still succeeds
+hid="$TMP/nosqlite"
+mkdir -p "$hid"
+for cmd in bash mkdir date sed git grep dirname cat rm mktemp printf; do
+  src="$(command -v "$cmd" || true)"
+  [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
+done
+cp "$TMP/bin/grok" "$hid/grok"
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+set +e
+PATH="$hid" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$TMP/workspace" FACTORY_OWNER=acme FACTORY_RUNNER=grok \
+  "$FACTORY" lead --issue 7 --repo widgets >"$TMP/nout" 2>"$TMP/nerr"
+ncode=$?
+set -e
+[[ $ncode -eq 0 ]] || fail "missing sqlite3 should not fail lead, exit $ncode err=$(cat "$TMP/nerr")"
+[[ -f "$DUMP/ran" ]] || fail "missing sqlite3 should still run lead"
+nwarns="$(grep -c "factory.db\|factory memory\|sqlite3" "$TMP/nerr" || true)"
+[[ "$nwarns" == "1" ]] || fail "missing sqlite3 should warn once, got $nwarns: $(cat "$TMP/nerr")"
+
+echo "ok lead"

--- a/tests/lead.sh
+++ b/tests/lead.sh
@@ -77,6 +77,13 @@ grep -q "QA the PR" "$DUMP/prompt" || fail "lead prompt missing next_steps: $(ca
 after="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
 [[ "$before" == "$after" ]] || fail "lead must not write runs, before=$before after=$after"
 
+# Issue rows from another project still reach lead. mem read is issue, not issue AND project.
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+"$FACTORY" mem write --harness grok --project other/repo --lane feature --status done --issue 7 --summary "Shipped on other remote" --evidence "https://github.com/other/repo/issues/7" >/dev/null
+run_lead >"$TMP/out3" 2>"$TMP/err3"
+grep -q "Shipped on other remote" "$DUMP/prompt" || fail "lead should see issue 7 from another project: $(cat "$DUMP/prompt")"
+
 # sqlite3 missing: warn once, lead still succeeds
 hid="$TMP/nosqlite"
 mkdir -p "$hid"


### PR DESCRIPTION
`factory.sh lead` now injects recent memory rows into the Tech lead prompt, and `/lead` reads them before classifying. Empty or missing memory still classifies from the ticket. Dispatch stays with Tech lead. Lanes still do not chain. References Kripu77/software-factory#7.