### PR TITLE
Feat/6/remaining lanes write memory and comment

### DIFF
--- a/commands/ci.md
+++ b/commands/ci.md
@@ -4,3 +4,5 @@ description: Watch gh pr checks until green and fix failures on this branch. Do 
 ---
 
 Read `lanes/ci.md` and `AGENTS.md`. Run /loop-on-ci on the given PR only. Never --no-verify. Never merge.
+
+At start, factory.sh mem read for this PR. Write started only if none in progress: factory.sh mem write --lane ci --status started --harness <claude|cursor|codex|grok> --pr <n>. At the end, factory.sh mem write --lane ci --status done|blocked|failed --harness <claude|cursor|codex|grok> --pr <n> --summary "<one sentence>" --evidence <url-or-path> --next-steps "<what should happen next>". That write comments on the GitHub issue or PR. started does not. Missing memory or a comment failure: warn once and continue.

--- a/commands/docs.md
+++ b/commands/docs.md
@@ -4,3 +4,5 @@ description: Docs-only change for a ready-for-agent ticket. No application code.
 ---
 
 Read `lanes/docs.md` and `AGENTS.md`. Need a GitHub issue. Open a PR. Do not merge.
+
+At start, factory.sh mem read for this issue. Write started only if that read shows no in-progress docs run: factory.sh mem write --lane docs --status started --harness <claude|cursor|codex|grok> --issue <n>. At the end, factory.sh mem write --lane docs --status done|blocked|failed --harness <claude|cursor|codex|grok> --issue <n> --summary "<one sentence>" --evidence <url-or-path> --next-steps "<what should happen next>". That write comments on the GitHub issue. started does not. Missing memory or a comment failure: warn once and continue.

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -5,4 +5,6 @@ description: Implement a ready-for-agent feature ticket in this checkout. Do not
 
 Read `lanes/feature.md` and `AGENTS.md`. Follow /tdd, /implement, /unslop.
 
+At start, factory.sh mem read for this issue. Write started only if that read shows no in-progress feature run: factory.sh mem write --lane feature --status started --harness <claude|cursor|codex|grok> --issue <n>. At the end, factory.sh mem write --lane feature --status done|blocked|failed --harness <claude|cursor|codex|grok> --issue <n> --summary "<one sentence>" --evidence <url-or-path> --next-steps "<what should happen next>". That write comments on the GitHub issue. started does not. Missing memory or a comment failure: warn once and continue.
+
 Need a GitHub issue (owner/repo#n or --repo and --issue). New branch off main. Open a PR. Print the URL. Do not merge.

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -4,3 +4,5 @@ description: Smoke or browser-walk a running app. Report only. Do not implement.
 ---
 
 Read `lanes/qa.md` and `AGENTS.md`. Prefer /run-smoke-tests when a suite exists. Otherwise /browser-use. Report findings. Do not implement. Do not merge.
+
+At start, factory.sh mem read for this issue or PR. Write started only if none in progress: factory.sh mem write --lane qa --status started --harness <claude|cursor|codex|grok> --issue <n>. At the end, factory.sh mem write --lane qa --status done|blocked|failed --harness <claude|cursor|codex|grok> --issue <n> --summary "<one sentence>" --evidence <url-or-path> --next-steps "<what should happen next>". That write comments on the GitHub issue. started does not. Missing memory or a comment failure: warn once and continue.

--- a/commands/review.md
+++ b/commands/review.md
@@ -4,3 +4,5 @@ description: Harsh maintainability review of one PR. Comments, not patches. Do n
 ---
 
 Read `lanes/review.md` and `AGENTS.md`. Run /thermo-nuclear-code-quality-review on the given PR only. Leave GitHub review comments. Do not implement. Do not merge.
+
+At start, factory.sh mem read for this PR. Write started only if none in progress: factory.sh mem write --lane review --status started --harness <claude|cursor|codex|grok> --pr <n>. At the end, factory.sh mem write --lane review --status done|blocked|failed --harness <claude|cursor|codex|grok> --pr <n> --summary "<one sentence>" --evidence <url-or-path> --next-steps "<what should happen next>". That write comments on the GitHub issue or PR. started does not. Missing memory or a comment failure: warn once and continue.

--- a/commands/telemetry.md
+++ b/commands/telemetry.md
@@ -4,3 +4,5 @@ description: Pull breakage or product-performance evidence. Funnels, feature com
 ---
 
 Read `lanes/telemetry.md` and `telemetry/CONTRACT.md`. Answer the question with evidence only. Name the adapter. Do not classify. Do not invent replays or funnels. Do not merge.
+
+At start, factory.sh mem read for this issue if one was given. Write started only if none in progress: factory.sh mem write --lane telemetry --status started --harness <claude|cursor|codex|grok> --issue <n>. At the end, factory.sh mem write --lane telemetry --status done|blocked|failed --harness <claude|cursor|codex|grok> --issue <n> --summary "<one sentence>" --evidence <url-or-path> --next-steps "<what should happen next>". That write comments on the GitHub issue when an issue is set. started does not. Missing memory or a comment failure: warn once and continue.

--- a/factory.sh
+++ b/factory.sh
@@ -455,7 +455,9 @@ SELECT last_insert_rowid();"
   fi
   id="$(sqlite_tx "$db" "$sql")"
   echo "id=$id status=$STATUS"
-  ticket_comment
+  if [[ "${FACTORY_SKIP_TICKET_COMMENT:-}" != 1 ]]; then
+    ticket_comment
+  fi
 }
 
 MEM_WARNED=0
@@ -469,8 +471,8 @@ warn_mem() {
 }
 
 ticket_comment() {
-  local body err code url
-  case "${RUN_LANE:-}" in
+  local body err code url lane="${1:-${RUN_LANE:-$LANE}}"
+  case "$lane" in
     feature|docs|qa|review|ci|telemetry) ;;
     *) return 0 ;;
   esac
@@ -506,90 +508,6 @@ ticket_comment() {
     warn_mem "$(cat "$err")"
   fi
   rm -f "$err"
-}
-
-bug_mem_write() {
-  local status="$1" err code
-  shift
-  err="$(mktemp)"
-  set +e
-  "$FACTORY/factory.sh" mem write \
-    --lane bug \
-    --status "$status" \
-    --harness "$RUNNER" \
-    --issue "$ISSUE" \
-    ${OWNER:+--owner "$OWNER"} \
-    ${REPO:+--repo "$REPO"} \
-    "$@" \
-    >/dev/null 2>"$err"
-  code=$?
-  set -e
-  if [[ $code -ne 0 ]]; then
-    warn_mem "$(cat "$err")"
-  fi
-  rm -f "$err"
-}
-
-bug_mem_start() {
-  local err code
-  MEM_WARNED=0
-  MEM_CONTEXT=""
-  err="$(mktemp)"
-  set +e
-  MEM_CONTEXT="$("$FACTORY/factory.sh" mem read --issue "$ISSUE" 2>"$err")"
-  code=$?
-  set -e
-  if [[ $code -ne 0 || -s "$err" ]]; then
-    warn_mem "$(cat "$err")"
-  fi
-  rm -f "$err"
-}
-
-bug_latest_status() {
-  local rec_lane="" rec_st=""
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    case "$line" in
-      *"lane = "*) rec_lane="${line##* = }" ;;
-      *"status = "*) rec_st="${line##* = }" ;;
-      "")
-        if [[ "$rec_lane" == "bug" ]]; then
-          printf '%s\n' "$rec_st"
-          return 0
-        fi
-        rec_lane=""
-        rec_st=""
-        ;;
-    esac
-  done
-  if [[ "$rec_lane" == "bug" ]]; then
-    printf '%s\n' "$rec_st"
-  fi
-}
-
-bug_mem_finish() {
-  local code="$1" status latest err rec_status
-  err="$(mktemp)"
-  set +e
-  latest="$("$FACTORY/factory.sh" mem read --issue "$ISSUE" 2>"$err")"
-  set -e
-  if [[ -s "$err" ]]; then
-    warn_mem "$(cat "$err")"
-  fi
-  rm -f "$err"
-  rec_status="$(printf '%s\n' "$latest" | bug_latest_status)"
-  case "$rec_status" in
-    blocked|done|failed) return 0 ;;
-  esac
-  if [[ "$code" -eq 0 ]]; then
-    status=done
-  else
-    status=failed
-  fi
-  local extra=(--summary "Bug lane ${status}." --next-steps "Tech lead dispatches the next lane.")
-  if [[ -n "$OWNER" && -n "$REPO" && -n "$ISSUE" ]]; then
-    extra+=(--evidence "https://github.com/${OWNER}/${REPO}/issues/${ISSUE}")
-  fi
-  bug_mem_write "$status" "${extra[@]}"
 }
 
 mem_read_context() {
@@ -679,20 +597,27 @@ lane_mem_finish() {
   rm -f "$err"
   rec_status="$(printf '%s\n' "$latest" | latest_lane_status "$lane")"
   case "$rec_status" in
-    blocked|done|failed) return 0 ;;
+    blocked|done|failed) ;;
+    *)
+      if [[ "$code" -eq 0 ]]; then
+        status=done
+      else
+        status=failed
+      fi
+      extra=(--summary "${lane} lane ${status}." --next-steps "Tech lead dispatches the next lane.")
+      if [[ -n "$OWNER" && -n "$REPO" && -n "$ISSUE" ]]; then
+        extra+=(--evidence "https://github.com/${OWNER}/${REPO}/issues/${ISSUE}")
+      elif [[ -n "$OWNER" && -n "$REPO" && -n "$PR" ]]; then
+        extra+=(--evidence "https://github.com/${OWNER}/${REPO}/pull/${PR}")
+      fi
+      lane_mem_write "$lane" "$status" "${extra[@]}"
+      rec_status="$status"
+      SUMMARY="${lane} lane ${status}."
+      NEXT_STEPS="Tech lead dispatches the next lane."
+      ;;
   esac
-  if [[ "$code" -eq 0 ]]; then
-    status=done
-  else
-    status=failed
-  fi
-  extra=(--summary "${lane} lane ${status}." --next-steps "Tech lead dispatches the next lane.")
-  if [[ -n "$OWNER" && -n "$REPO" && -n "$ISSUE" ]]; then
-    extra+=(--evidence "https://github.com/${OWNER}/${REPO}/issues/${ISSUE}")
-  elif [[ -n "$OWNER" && -n "$REPO" && -n "$PR" ]]; then
-    extra+=(--evidence "https://github.com/${OWNER}/${REPO}/pull/${PR}")
-  fi
-  lane_mem_write "$lane" "$status" "${extra[@]}"
+  STATUS="$rec_status"
+  ticket_comment "$lane"
 }
 
 run_mem_lane() {
@@ -702,11 +627,13 @@ run_mem_lane() {
   if [[ -n "${MEM_CONTEXT:-}" ]]; then
     prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
   fi
+  export FACTORY_SKIP_TICKET_COMMENT=1
   set +e
   run_agent "$dir" "$rules" "$prompt"
   code=$?
   set -e
   lane_mem_finish "$lane" "$code"
+  unset FACTORY_SKIP_TICKET_COMMENT
   return "$code"
 }
 
@@ -718,27 +645,11 @@ case "$LANE" in
       *) usage ;;
     esac
     ;;
-  feature|docs)
+  feature|bug|docs)
     need_issue
     DIR="$(repo_dir)"
     run_mem_lane "$LANE" "$DIR" "$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD" "Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
     exit $?
-    ;;
-  bug)
-    need_issue
-    DIR="$(repo_dir)"
-    bug_mem_start
-    prompt="Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
-    prompt+=$'\n'"Memory writes: factory.sh mem write --lane bug --harness $RUNNER --issue $ISSUE --summary '<one sentence>' --evidence <url-or-path> --next-steps '<next>'."
-    if [[ -n "${MEM_CONTEXT:-}" ]]; then
-      prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
-    fi
-    set +e
-    run_agent "$DIR" "$(cat "$FACTORY/lanes/bug.md")"$'\n'"$HARD" "$prompt"
-    code=$?
-    set -e
-    bug_mem_finish "$code"
-    exit "$code"
     ;;
   review)
     need_pr
@@ -772,7 +683,7 @@ case "$LANE" in
     ;;
   lead|tech-lead|cto)
     need_issue
-    bug_mem_start
+    mem_read_context
     prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}."
     if [[ -n "${MEM_CONTEXT:-}" ]]; then
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"

--- a/factory.sh
+++ b/factory.sh
@@ -16,7 +16,7 @@ Usage:
   factory.sh telemetry        --question "<what broke>" [--yes]
   factory.sh qa               --repo <name> --pr <n> [--url <app>]
   factory.sh qa               --url <app>
-  factory.sh mem read         [--issue <n>] [--project owner/name] [--limit n]
+  factory.sh mem read         [--issue <n>] [--pr <n>] [--project owner/name] [--limit n]
   factory.sh mem write        --lane <lane> --status started|done|blocked|failed [--harness grok|claude|codex|cursor] [--issue <n>] [--pr <n>] [--project owner/name] [--summary s] [--next-steps s] [--evidence url-or-json]
 
 Never merges. A person merges.
@@ -377,6 +377,13 @@ mem_read() {
   if [[ -n "$ISSUE" ]]; then
     where="issue = $(sql_quote "$ISSUE")"
   fi
+  if [[ -n "$PR" ]]; then
+    if [[ -n "$where" ]]; then
+      where="$where AND pr = $(sql_quote "$PR")"
+    else
+      where="pr = $(sql_quote "$PR")"
+    fi
+  fi
   if [[ -n "$PROJECT" ]]; then
     if [[ -n "$where" ]]; then
       where="$where AND project = $(sql_quote "$PROJECT")"
@@ -448,6 +455,7 @@ SELECT last_insert_rowid();"
   fi
   id="$(sqlite_tx "$db" "$sql")"
   echo "id=$id status=$STATUS"
+  ticket_comment
 }
 
 MEM_WARNED=0
@@ -458,6 +466,46 @@ warn_mem() {
   MEM_WARNED=1
   [[ -n "${1:-}" ]] || return 0
   printf '%s\n' "$1" >&2
+}
+
+ticket_comment() {
+  local body err code url
+  case "${RUN_LANE:-}" in
+    feature|docs|qa|review|ci|telemetry) ;;
+    *) return 0 ;;
+  esac
+  case "${STATUS:-}" in
+    done|blocked|failed) ;;
+    *) return 0 ;;
+  esac
+  [[ -n "${OWNER:-}" && -n "${REPO:-}" ]] || return 0
+  [[ -n "${ISSUE:-}" || -n "${PR:-}" ]] || return 0
+  command -v gh >/dev/null 2>&1 || { warn_mem "gh not installed"; return 0; }
+  body="$STATUS"
+  [[ -n "${SUMMARY:-}" ]] && body+=$'\n'"$SUMMARY"
+  if [[ -n "${ISSUE:-}" ]]; then
+    url="https://github.com/${OWNER}/${REPO}/issues/${ISSUE}"
+  else
+    url="https://github.com/${OWNER}/${REPO}/pull/${PR}"
+  fi
+  body+=$'\n'"$url"
+  if [[ -n "${EVIDENCE:-}" && "$EVIDENCE" != "[]" ]]; then
+    body+=$'\n'"$EVIDENCE"
+  fi
+  [[ -n "${NEXT_STEPS:-}" ]] && body+=$'\n'"$NEXT_STEPS"
+  err="$(mktemp)"
+  set +e
+  if [[ -n "${ISSUE:-}" ]]; then
+    gh issue comment "$ISSUE" -R "${OWNER}/${REPO}" --body "$body" >/dev/null 2>"$err"
+  else
+    gh pr comment "$PR" -R "${OWNER}/${REPO}" --body "$body" >/dev/null 2>"$err"
+  fi
+  code=$?
+  set -e
+  if [[ $code -ne 0 ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
 }
 
 bug_mem_write() {
@@ -544,6 +592,124 @@ bug_mem_finish() {
   bug_mem_write "$status" "${extra[@]}"
 }
 
+mem_read_context() {
+  local err code args=()
+  MEM_WARNED=0
+  MEM_CONTEXT=""
+  if [[ -n "${ISSUE:-}" ]]; then
+    args+=(--issue "$ISSUE")
+  elif [[ -n "${PR:-}" ]]; then
+    args+=(--pr "$PR")
+  else
+    return 0
+  fi
+  err="$(mktemp)"
+  set +e
+  MEM_CONTEXT="$("$FACTORY/factory.sh" mem read "${args[@]}" 2>"$err")"
+  code=$?
+  set -e
+  if [[ $code -ne 0 || -s "$err" ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
+}
+
+lane_mem_write() {
+  local lane="$1" status="$2" err code
+  shift 2
+  err="$(mktemp)"
+  set +e
+  "$FACTORY/factory.sh" mem write \
+    --lane "$lane" \
+    --status "$status" \
+    --harness "$RUNNER" \
+    ${ISSUE:+--issue "$ISSUE"} \
+    ${PR:+--pr "$PR"} \
+    ${OWNER:+--owner "$OWNER"} \
+    ${REPO:+--repo "$REPO"} \
+    "$@" \
+    >/dev/null 2>"$err"
+  code=$?
+  set -e
+  if [[ $code -ne 0 || -s "$err" ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
+}
+
+latest_lane_status() {
+  local want="$1" rec_lane="" rec_st=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      *"lane = "*) rec_lane="${line##* = }" ;;
+      *"status = "*) rec_st="${line##* = }" ;;
+      "")
+        if [[ "$rec_lane" == "$want" ]]; then
+          printf '%s\n' "$rec_st"
+          return 0
+        fi
+        rec_lane=""
+        rec_st=""
+        ;;
+    esac
+  done
+  if [[ "$rec_lane" == "$want" ]]; then
+    printf '%s\n' "$rec_st"
+  fi
+}
+
+lane_mem_finish() {
+  local lane="$1" code="$2" status latest err rec_status args=() extra
+  err="$(mktemp)"
+  if [[ -n "${ISSUE:-}" ]]; then
+    args+=(--issue "$ISSUE")
+  elif [[ -n "${PR:-}" ]]; then
+    args+=(--pr "$PR")
+  fi
+  set +e
+  if [[ ${#args[@]} -gt 0 ]]; then
+    latest="$("$FACTORY/factory.sh" mem read "${args[@]}" 2>"$err")"
+  else
+    latest=""
+  fi
+  set -e
+  if [[ -s "$err" ]]; then
+    warn_mem "$(cat "$err")"
+  fi
+  rm -f "$err"
+  rec_status="$(printf '%s\n' "$latest" | latest_lane_status "$lane")"
+  case "$rec_status" in
+    blocked|done|failed) return 0 ;;
+  esac
+  if [[ "$code" -eq 0 ]]; then
+    status=done
+  else
+    status=failed
+  fi
+  extra=(--summary "${lane} lane ${status}." --next-steps "Tech lead dispatches the next lane.")
+  if [[ -n "$OWNER" && -n "$REPO" && -n "$ISSUE" ]]; then
+    extra+=(--evidence "https://github.com/${OWNER}/${REPO}/issues/${ISSUE}")
+  elif [[ -n "$OWNER" && -n "$REPO" && -n "$PR" ]]; then
+    extra+=(--evidence "https://github.com/${OWNER}/${REPO}/pull/${PR}")
+  fi
+  lane_mem_write "$lane" "$status" "${extra[@]}"
+}
+
+run_mem_lane() {
+  local lane="$1" dir="$2" rules="$3" prompt="$4" code
+  mem_read_context
+  prompt+=$'\n'"Memory writes: factory.sh mem write --lane $lane --harness $RUNNER ${ISSUE:+--issue $ISSUE }${PR:+--pr $PR }--summary '<one sentence>' --evidence <url-or-path> --next-steps '<next>'."
+  if [[ -n "${MEM_CONTEXT:-}" ]]; then
+    prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
+  fi
+  set +e
+  run_agent "$dir" "$rules" "$prompt"
+  code=$?
+  set -e
+  lane_mem_finish "$lane" "$code"
+  return "$code"
+}
+
 case "$LANE" in
   mem)
     case "$MEM_CMD" in
@@ -555,7 +721,8 @@ case "$LANE" in
   feature|docs)
     need_issue
     DIR="$(repo_dir)"
-    run_agent "$DIR" "$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD"       "Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
+    run_mem_lane "$LANE" "$DIR" "$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD" "Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
+    exit $?
     ;;
   bug)
     need_issue
@@ -576,7 +743,8 @@ case "$LANE" in
   review)
     need_pr
     DIR="$(repo_dir)"
-    run_agent "$DIR" "$(cat "$FACTORY/lanes/review.md")"$'\n'"$HARD"       "Review $(pr_url "$PR") only. Use /thermo-nuclear-code-quality-review. Do not implement. Do not merge."
+    run_mem_lane review "$DIR" "$(cat "$FACTORY/lanes/review.md")"$'\n'"$HARD" "Review $(pr_url "$PR") only. Use /thermo-nuclear-code-quality-review. Do not implement. Do not merge."
+    exit $?
     ;;
   ci)
     need_pr
@@ -585,9 +753,11 @@ case "$LANE" in
     command -v gh >/dev/null 2>&1 || { echo "gh not installed" >&2; exit 1; }
     echo "Checks before:"
     gh pr checks "$PR" -R "${OWNER}/${REPO}" || true
-    run_agent "$DIR" "$(cat "$FACTORY/lanes/ci.md")"$'\n'"$HARD"       "Watch $(pr_url "$PR") with gh pr checks until green. Fix failures on this branch. Do not merge."
+    run_mem_lane ci "$DIR" "$(cat "$FACTORY/lanes/ci.md")"$'\n'"$HARD" "Watch $(pr_url "$PR") with gh pr checks until green. Fix failures on this branch. Do not merge."
+    code=$?
     echo "Checks after:"
     gh pr checks "$PR" -R "${OWNER}/${REPO}" || true
+    exit "$code"
     ;;
   ship)
     need_issue
@@ -611,7 +781,8 @@ case "$LANE" in
     ;;
   telemetry)
     need_question
-    run_agent "$WORKSPACE" "$(cat "$FACTORY/lanes/telemetry.md")"$'\n'"$HARD"$'\n'"$(cat "$FACTORY/telemetry/CONTRACT.md")"       "Answer this with evidence only: ${QUESTION}. Name the adapter you used. Do not implement product code. Do not merge."
+    run_mem_lane telemetry "$WORKSPACE" "$(cat "$FACTORY/lanes/telemetry.md")"$'\n'"$HARD"$'\n'"$(cat "$FACTORY/telemetry/CONTRACT.md")" "Answer this with evidence only: ${QUESTION}. Name the adapter you used. Do not implement product code. Do not merge."
+    exit $?
     ;;
   qa)
     [[ -n "$URL" || -n "$PR" ]] || { echo "Need --url <app> or --pr <n>" >&2; exit 1; }
@@ -620,7 +791,8 @@ case "$LANE" in
     else
       DIR="$WORKSPACE"
     fi
-    run_agent "$DIR" "$(cat "$FACTORY/lanes/qa.md")"$'\n'"$HARD"       "QA the running app. URL: ${URL:-from the PR / local}. PR: ${PR:-none}. Prefer /run-smoke-tests if a suite exists, else /browser-use. Report only. Do not implement. Do not merge."
+    run_mem_lane qa "$DIR" "$(cat "$FACTORY/lanes/qa.md")"$'\n'"$HARD" "QA the running app. URL: ${URL:-from the PR / local}. PR: ${PR:-none}. Prefer /run-smoke-tests if a suite exists, else /browser-use. Report only. Do not implement. Do not merge."
+    exit $?
     ;;
   *)
     usage

--- a/lanes/ci.md
+++ b/lanes/ci.md
@@ -1,5 +1,7 @@
 You are the factory CI Loop.
 
+At start, factory.sh mem read for this PR. Write started only if that read shows no in-progress ci run. Missing memory: warn once and continue.
+
 Run /loop-on-ci on the given PR only.
 Never merge. Never --no-verify.
-When your job is done, report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/docs.md
+++ b/lanes/docs.md
@@ -1,5 +1,7 @@
 You are the factory Docs lane.
 
+At start, factory.sh mem read for this issue. Write started only if that read shows no in-progress docs run. Missing memory: warn once and continue.
+
 Docs only. No application code. Short pages, tables, mermaid, decisions, file paths, PR links.
 Never merge. Never read .env.
-When your job is done, report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/feature.md
+++ b/lanes/feature.md
@@ -1,7 +1,9 @@
 You are the factory Feature lane.
 
+At start, factory.sh mem read for this issue. Write started only if that read shows no in-progress feature run. Missing memory: warn once and continue.
+
 Do not expand the ask. Follow /tdd, /implement, /unslop.
 If the ticket came from a funnel or feature-performance signal, keep the change on that path.
 Work only on the ticket in this prompt. New branch off main.
 Never merge. Never read .env. Never touch other PRs.
-When your job is done, report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/qa.md
+++ b/lanes/qa.md
@@ -1,8 +1,10 @@
 You are the factory QA lane.
 
+At start, factory.sh mem read for this issue or PR. Write started only if that read shows no in-progress qa run. Missing memory: warn once and continue.
+
 Report only. Never implement product code. Never merge.
 If the checkout has a Playwright or smoke suite, follow /run-smoke-tests.
 Otherwise follow /browser-use against the given URL or local app.
 Screenshot evidence. Repro every failure.
 Only the dispatched ticket, PR, or URL.
-When your job is done, report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/review.md
+++ b/lanes/review.md
@@ -1,5 +1,7 @@
 You are the factory Reviewer.
 
+At start, factory.sh mem read for this PR. Write started only if that read shows no in-progress review run. Missing memory: warn once and continue.
+
 Run /thermo-nuclear-code-quality-review on the given PR only.
 Do not implement. Do not merge. Leave GitHub review comments.
-When your job is done, report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/telemetry.md
+++ b/lanes/telemetry.md
@@ -1,10 +1,9 @@
 You are the factory Telemetry lane.
 
-You do not own a vendor. You implement the contract in telemetry/CONTRACT.md.
-Pick the adapter that is actually connected.
+At start, factory.sh mem read for this issue if one was given. Write started only if that read shows no in-progress telemetry run. Missing memory: warn once and continue.
 
-Bring evidence for breakage and for product performance. Funnels are any instrumented path (signup, onboarding, core loop, invite, checkout, a feature happy path), not a single screen. Feature performance is adoption, completion, time-to-value, and error rate on that path.
-
-Name the path, the step that dies or lags, volume, and window. Do not classify as bug vs feature. Do not invent replays or funnels the vendor cannot produce.
+You do not own a vendor. Implement telemetry/CONTRACT.md. Pick the adapter that is actually connected.
+Bring evidence for breakage and product performance. Funnels are any instrumented path, not one screen.
+Name the path, the step that dies or lags, volume, and window. Do not classify. Do not invent replays or funnels the vendor cannot produce.
 Never implement product code. Never merge.
-When your job is done, report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.
+When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/tests/bug.sh
+++ b/tests/bug.sh
@@ -117,9 +117,12 @@ bytes_under lanes/bug.md 1000
 bytes_under commands/bug.md 1000
 grep -q -- "--summary" "$ROOT/lanes/bug.md" && fail "put mem flags in /bug or the injected prompt, not a second dump in the lane"
 
-fn_body bug_mem_start | grep -Eq 'bug_mem_write started|--status started' && fail "wrapper must not write started"
-fn_body bug_mem_finish | grep -q sqlite3 && fail "bug_mem_finish must not call sqlite3"
-fn_body bug_mem_finish | grep -q "mem read\|bug_mem_write\|mem write" || fail "bug_mem_finish must go through factory.sh mem"
+fn_body mem_read_context | grep -Eq 'lane_mem_write started|--status started' && fail "wrapper must not write started"
+fn_body lane_mem_finish | grep -q sqlite3 && fail "lane_mem_finish must not call sqlite3"
+fn_body lane_mem_finish | grep -q "mem read\|lane_mem_write\|mem write" || fail "lane_mem_finish must go through factory.sh mem"
+if grep -Eq "bug_mem_start|bug_mem_finish|bug_mem_write|bug_latest_status" "$ROOT/factory.sh"; then
+  fail "fold bug into run_mem_lane"
+fi
 
 # Missing DB: warn once, lane still succeeds, finish records done
 rm -rf "$DUMP" "$TMP/memory"

--- a/tests/lanes.sh
+++ b/tests/lanes.sh
@@ -56,6 +56,10 @@ playbook review review
 playbook ci ci
 playbook telemetry telemetry
 
+if grep -Eq "bug_mem_start|bug_mem_finish|bug_mem_write|bug_latest_status" "$ROOT/factory.sh"; then
+  fail "fold bug into run_mem_lane"
+fi
+
 WS="$TMP/workspace"
 mkdir -p "$WS/widgets"
 git -C "$WS/widgets" init -q
@@ -75,11 +79,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 : > "$dump/ran"
+own=()
+if [[ -z "${GROK_NO_OWNER:-}" ]]; then
+  own=(--owner acme --repo widgets)
+fi
 if [[ -n "${GROK_MEM_START:-}" ]]; then
-  "${FACTORY_SH:?}" mem write --lane "${GROK_LANE:?}" --status started --harness grok --issue "${GROK_ISSUE:-6}" --pr "${GROK_PR:-}" --project acme/widgets --owner acme --repo widgets >/dev/null
+  "${FACTORY_SH:?}" mem write --lane "${GROK_LANE:?}" --status started --harness grok ${GROK_ISSUE:+--issue "$GROK_ISSUE"} ${GROK_PR:+--pr "$GROK_PR"} --project acme/widgets "${own[@]}" >/dev/null
 fi
 if [[ -n "${GROK_MEM_STATUS:-}" ]]; then
-  "${FACTORY_SH:?}" mem write --lane "${GROK_LANE:?}" --status "$GROK_MEM_STATUS" --harness grok --issue "${GROK_ISSUE:-6}" --pr "${GROK_PR:-}" --project acme/widgets --owner acme --repo widgets --summary "${GROK_SUMMARY:-Lane finished}" --evidence "${GROK_EVIDENCE:-https://github.com/acme/widgets/issues/6}" --next-steps "${GROK_NEXT:-Tech lead dispatches the next lane}" >/dev/null
+  "${FACTORY_SH:?}" mem write --lane "${GROK_LANE:?}" --status "$GROK_MEM_STATUS" --harness grok ${GROK_ISSUE:+--issue "$GROK_ISSUE"} ${GROK_PR:+--pr "$GROK_PR"} --project acme/widgets "${own[@]}" --summary "${GROK_SUMMARY:-Lane finished}" --evidence "${GROK_EVIDENCE:-https://github.com/acme/widgets/issues/6}" --next-steps "${GROK_NEXT:-Tech lead dispatches the next lane}" >/dev/null
 fi
 exit "${GROK_EXIT:-0}"
 EOF
@@ -165,13 +173,29 @@ grep -q "status = done" "$DUMP/prompt" || fail "second feature should see first 
 # Agent started then blocked: one row, one comment, no extra done
 rm -rf "$DUMP" "$TMP/memory"
 mkdir -p "$DUMP"
-GROK_LANE=feature GROK_MEM_START=1 GROK_MEM_STATUS=blocked GROK_SUMMARY="Need a human" \
+GROK_LANE=feature GROK_ISSUE=6 GROK_MEM_START=1 GROK_MEM_STATUS=blocked GROK_SUMMARY="Need a human" \
   run_feature >"$TMP/bout" 2>"$TMP/berr"
 status="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE lane = 'feature' ORDER BY id DESC LIMIT 1;")"
 count="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE lane = 'feature';")"
 [[ "$status" == "blocked" ]] || fail "blocked should stick, got $status"
 [[ "$count" == "1" ]] || fail "started then blocked should be one row, count=$count"
 [[ "$(gh_count)" == "1" ]] || fail "blocked should comment once, got $(gh_count): $(cat "$DUMP/gh" 2>/dev/null || true)"
+
+# Agent done without --owner still comments once from finish
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+GROK_LANE=feature GROK_ISSUE=6 GROK_MEM_STATUS=done GROK_NO_OWNER=1 GROK_SUMMARY="Shipped without owner flags" \
+  run_feature >"$TMP/nout" 2>"$TMP/nerr"
+[[ "$(gh_count)" == "1" ]] || fail "finish should comment when agent omitted owner, got $(gh_count): $(cat "$DUMP/gh" 2>/dev/null || true)"
+grep -q "issue comment 6" "$DUMP/gh" || fail "finish comment should be issue comment: $(cat "$DUMP/gh")"
+
+# factory.sh review writes memory and comments on the PR
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+GROK_LANE=review GROK_PR=40 run_env "$FACTORY" review --repo widgets --pr 40 >"$TMP/rout" 2>"$TMP/rerr"
+rstatus="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE lane = 'review' ORDER BY id DESC LIMIT 1;")"
+[[ "$rstatus" == "done" ]] || fail "review finish should be done, got $rstatus"
+grep -q "pr comment 40" "$DUMP/gh" || fail "review finish should gh pr comment: $(cat "$DUMP/gh" 2>/dev/null || true)"
 
 # Comment failure does not fail the lane
 rm -rf "$DUMP" "$TMP/memory"

--- a/tests/lanes.sh
+++ b/tests/lanes.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+need_text() {
+  local file="$1" pat="$2"
+  grep -q -- "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+}
+
+bytes_under() {
+  local file="$1" max="$2" n
+  n="$(wc -c < "$ROOT/$file" | tr -d ' ')"
+  [[ "$n" -lt "$max" ]] || fail "$file is $n bytes, stay under $max"
+}
+
+playbook() {
+  local lane="$1" cmd="$2"
+  need_text "lanes/${lane}.md" "mem read"
+  need_text "lanes/${lane}.md" "mem write"
+  need_text "lanes/${lane}.md" "started"
+  need_text "lanes/${lane}.md" "done"
+  need_text "lanes/${lane}.md" "blocked"
+  need_text "lanes/${lane}.md" "failed"
+  need_text "lanes/${lane}.md" "warn once"
+  need_text "lanes/${lane}.md" "Tech lead"
+  need_text "lanes/${lane}.md" "Do not dispatch"
+  need_text "lanes/${lane}.md" "in-progress"
+  need_text "commands/${cmd}.md" "mem read"
+  need_text "commands/${cmd}.md" "mem write"
+  need_text "commands/${cmd}.md" "started"
+  need_text "commands/${cmd}.md" "done"
+  need_text "commands/${cmd}.md" "--harness"
+  need_text "commands/${cmd}.md" "--summary"
+  need_text "commands/${cmd}.md" "--evidence"
+  need_text "commands/${cmd}.md" "--next-steps"
+  need_text "commands/${cmd}.md" "comment"
+  bytes_under "lanes/${lane}.md" 1000
+  bytes_under "commands/${cmd}.md" 1000
+  if grep -q -- "--summary" "$ROOT/lanes/${lane}.md"; then
+    fail "put mem flags in /${cmd}, not ${lane} lane"
+  fi
+}
+
+playbook feature feature
+playbook docs docs
+playbook qa qa
+playbook review review
+playbook ci ci
+playbook telemetry telemetry
+
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
+DUMP="$TMP/dump"
+mkdir -p "$DUMP" "$TMP/bin"
+
+cat > "$TMP/bin/grok" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p) printf '%s\n' "$2" > "$dump/prompt"; shift 2 ;;
+    --rules) printf '%s\n' "$2" > "$dump/rules"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+: > "$dump/ran"
+if [[ -n "${GROK_MEM_START:-}" ]]; then
+  "${FACTORY_SH:?}" mem write --lane "${GROK_LANE:?}" --status started --harness grok --issue "${GROK_ISSUE:-6}" --pr "${GROK_PR:-}" --project acme/widgets --owner acme --repo widgets >/dev/null
+fi
+if [[ -n "${GROK_MEM_STATUS:-}" ]]; then
+  "${FACTORY_SH:?}" mem write --lane "${GROK_LANE:?}" --status "$GROK_MEM_STATUS" --harness grok --issue "${GROK_ISSUE:-6}" --pr "${GROK_PR:-}" --project acme/widgets --owner acme --repo widgets --summary "${GROK_SUMMARY:-Lane finished}" --evidence "${GROK_EVIDENCE:-https://github.com/acme/widgets/issues/6}" --next-steps "${GROK_NEXT:-Tech lead dispatches the next lane}" >/dev/null
+fi
+exit "${GROK_EXIT:-0}"
+EOF
+chmod +x "$TMP/bin/grok"
+
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/gh"
+if [[ "${GH_FAIL:-}" == 1 && "$1" == "issue" && "$2" == "comment" ]]; then
+  echo "comment failed" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+
+run_env() {
+  PATH="$TMP/bin:$PATH" \
+    FAKE_DUMP="$DUMP" \
+    FACTORY_SH="$FACTORY" \
+    FACTORY_WORKSPACE="$WS" \
+    FACTORY_OWNER=acme \
+    FACTORY_RUNNER=grok \
+    "$@"
+}
+
+run_feature() { run_env "$FACTORY" feature --repo widgets --issue 6; }
+
+gh_count() {
+  if [[ -f "$DUMP/gh" ]]; then
+    grep -c "comment" "$DUMP/gh" || true
+  else
+    echo 0
+  fi
+}
+
+# started does not comment
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+run_env "$FACTORY" mem write --lane feature --status started --harness grok --issue 6 --owner acme --repo widgets --project acme/widgets --summary "Start feature" >/dev/null
+[[ "$(gh_count)" == "0" ]] || fail "started must not comment: $(cat "$DUMP/gh")"
+
+# Terminal done comments once
+run_env "$FACTORY" mem write --lane feature --status done --harness grok --issue 6 --owner acme --repo widgets --project acme/widgets --summary "Shipped the list" --evidence "https://github.com/acme/widgets/pull/40" --next-steps "Review the PR" >/dev/null
+[[ "$(gh_count)" == "1" ]] || fail "done should comment once, got $(gh_count): $(cat "$DUMP/gh")"
+grep -q "issue comment 6" "$DUMP/gh" || fail "done should gh issue comment: $(cat "$DUMP/gh")"
+grep -q "Shipped the list" "$DUMP/gh" || fail "comment missing summary: $(cat "$DUMP/gh")"
+grep -q "Review the PR" "$DUMP/gh" || fail "comment missing next: $(cat "$DUMP/gh")"
+
+# Bug writes do not comment
+rm -f "$DUMP/gh"
+run_env "$FACTORY" mem write --lane bug --status done --harness grok --issue 6 --owner acme --repo widgets --project acme/widgets --summary "Fixed it" --evidence "https://github.com/acme/widgets/issues/6" >/dev/null
+[[ "$(gh_count)" == "0" ]] || fail "bug must not comment: $(cat "$DUMP/gh")"
+
+# Review comments on the PR
+rm -f "$DUMP/gh"
+run_env "$FACTORY" mem write --lane review --status done --harness grok --pr 40 --owner acme --repo widgets --project acme/widgets --summary "Left review comments" --evidence "https://github.com/acme/widgets/pull/40" --next-steps "CI" >/dev/null
+grep -q "pr comment 40" "$DUMP/gh" || fail "review should gh pr comment: $(cat "$DUMP/gh")"
+
+# Missing DB: feature still runs, finish writes done and comments
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+set +e
+run_feature >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -eq 0 ]] || fail "missing db feature exit $code err=$(cat "$TMP/err")"
+[[ -f "$DUMP/ran" ]] || fail "missing db should still run feature"
+warns="$(grep -c "factory.db\|factory memory" "$TMP/err" || true)"
+[[ "$warns" == "1" ]] || fail "missing db should warn once, got $warns: $(cat "$TMP/err")"
+status="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE lane = 'feature' ORDER BY id DESC LIMIT 1;")"
+[[ "$status" == "done" ]] || fail "feature finish should be done, got $status"
+[[ "$(gh_count)" == "1" ]] || fail "feature finish should comment once, got $(gh_count)"
+grep -q "acme/widgets" "$DUMP/prompt" || true
+
+# Second feature run sees prior memory
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+run_feature >"$TMP/out2" 2>"$TMP/err2"
+grep -q "status = done" "$DUMP/prompt" || fail "second feature should see first run: $(cat "$DUMP/prompt")"
+
+# Agent started then blocked: one row, one comment, no extra done
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+GROK_LANE=feature GROK_MEM_START=1 GROK_MEM_STATUS=blocked GROK_SUMMARY="Need a human" \
+  run_feature >"$TMP/bout" 2>"$TMP/berr"
+status="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE lane = 'feature' ORDER BY id DESC LIMIT 1;")"
+count="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE lane = 'feature';")"
+[[ "$status" == "blocked" ]] || fail "blocked should stick, got $status"
+[[ "$count" == "1" ]] || fail "started then blocked should be one row, count=$count"
+[[ "$(gh_count)" == "1" ]] || fail "blocked should comment once, got $(gh_count): $(cat "$DUMP/gh" 2>/dev/null || true)"
+
+# Comment failure does not fail the lane
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+run_env "$FACTORY" mem write --lane feature --status started --harness grok --issue 6 --owner acme --repo widgets --project acme/widgets >/dev/null
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+set +e
+GH_FAIL=1 run_feature >"$TMP/fout" 2>"$TMP/ferr"
+fcode=$?
+set -e
+[[ $fcode -eq 0 ]] || fail "comment failure should not fail feature, exit $fcode err=$(cat "$TMP/ferr")"
+[[ -f "$DUMP/ran" ]] || fail "comment failure should still run feature"
+grep -qi "comment" "$TMP/ferr" || fail "comment failure should warn: $(cat "$TMP/ferr")"
+
+# Telemetry without issue: mem write, no comment
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+run_env "$FACTORY" telemetry --question "where does signup die" --repo widgets >"$TMP/tout" 2>"$TMP/terr"
+tstatus="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT status FROM runs WHERE lane = 'telemetry' ORDER BY id DESC LIMIT 1;")"
+[[ "$tstatus" == "done" ]] || fail "telemetry should finish done, got $tstatus"
+[[ "$(gh_count)" == "0" ]] || fail "telemetry without issue must not comment: $(cat "$DUMP/gh" 2>/dev/null || true)"
+
+echo "ok lanes"


### PR DESCRIPTION
Feature, docs, QA, review, CI, and telemetry now read factory memory at start and write at end, same contract as bug. Terminal writes on done, blocked, or failed post one GitHub issue or PR comment; started does not. A missing database or a comment failure warns and the lane continues. References Kripu77/software-factory#6.