### PR TITLE
Feat/12/factory.sh floor dispatches isolated lanes

### DIFF
--- a/factory.sh
+++ b/factory.sh
@@ -432,13 +432,26 @@ WHERE id = (
   WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE") AND status = 'started'
   ORDER BY started_at_epoch DESC, id DESC
   LIMIT 1
-);
+);"
+    if [[ -n "$PR" ]]; then
+      sql+="
+UPDATE runs SET pr = $(sql_quote "$PR")
+WHERE changes() = 0 AND (pr IS NULL OR pr = '') AND id = (
+  SELECT id FROM (
+    SELECT id FROM runs
+    WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE")
+    ORDER BY started_at_epoch DESC, id DESC
+    LIMIT 1
+  )
+);"
+    fi
+    sql+="
 INSERT INTO runs (harness, lane, project, issue, pr, status, summary, next_steps, evidence, started_at, started_at_epoch, completed_at, completed_at_epoch)
 SELECT $(sql_quote "$HARNESS"), $(sql_quote "$RUN_LANE"), $(sql_quote "$PROJECT"), $(sql_nullable "$ISSUE"), $(sql_nullable "$PR"), $(sql_quote "$STATUS"), $(sql_nullable "$SUMMARY"), $(sql_nullable "$NEXT_STEPS"), $(sql_quote "$EVIDENCE"), $(sql_quote "$now"), $epoch, $(sql_quote "$now"), $epoch
 WHERE changes() = 0;
 SELECT COALESCE(
   (SELECT last_insert_rowid() WHERE last_insert_rowid() != 0 AND changes() != 0),
-  (SELECT id FROM runs WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE") AND completed_at_epoch = $epoch ORDER BY id DESC LIMIT 1)
+  (SELECT id FROM runs WHERE issue = $(sql_quote "$ISSUE") AND lane = $(sql_quote "$RUN_LANE") ORDER BY id DESC LIMIT 1)
 );"
   else
     if [[ "$STATUS" == "started" ]]; then
@@ -638,15 +651,16 @@ run_mem_lane() {
 }
 
 floor_classify() {
-  local labels=""
-  if command -v gh >/dev/null 2>&1 && [[ -n "$OWNER" && -n "$REPO" ]]; then
-    labels="$(gh issue view "$ISSUE" -R "${OWNER}/${REPO}" --json labels 2>/dev/null || true)"
-  fi
-  case "$labels" in
-    *'"bug"'*|*'name": "bug'*|*[Bb]ug*) printf '%s\n' bug ;;
-    *documentation*|*docs*) printf '%s\n' docs ;;
-    *) printf '%s\n' feature ;;
-  esac
+  local name
+  command -v gh >/dev/null 2>&1 || { printf '%s\n' feature; return 0; }
+  [[ -n "$OWNER" && -n "$REPO" ]] || { printf '%s\n' feature; return 0; }
+  while IFS= read -r name; do
+    case "$name" in
+      bug) printf '%s\n' bug; return 0 ;;
+      documentation|docs) printf '%s\n' docs; return 0 ;;
+    esac
+  done < <(gh issue view "$ISSUE" -R "${OWNER}/${REPO}" --json labels --template '{{range .labels}}{{.name}}{{"\n"}}{{end}}' 2>/dev/null || true)
+  printf '%s\n' feature
 }
 
 floor_mem() {
@@ -669,17 +683,22 @@ floor_pr_from_mem() {
 }
 
 floor_pr_from_gh() {
-  local num title
+  local head num
   command -v gh >/dev/null 2>&1 || return 0
   [[ -n "$OWNER" && -n "$REPO" ]] || return 0
-  while IFS=$'\t' read -r num title; do
-    case "$title" in
-      */"$ISSUE"/*)
-        printf '%s\n' "$num"
-        return 0
-        ;;
-    esac
-  done < <(gh pr list -R "${OWNER}/${REPO}" --state open --json number,title --template '{{range .}}{{.number}}	{{.title}}{{"\n"}}{{end}}' 2>/dev/null || true)
+  head="$(git -C "$(repo_dir 2>/dev/null || echo "$WORKSPACE")" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [[ -n "$head" && "$head" != "main" && "$head" != "master" ]]; then
+    num="$(gh pr view --head "$head" -R "${OWNER}/${REPO}" --json number --template '{{.number}}' 2>/dev/null || true)"
+  else
+    num="$(gh pr view -R "${OWNER}/${REPO}" --json number --template '{{.number}}' 2>/dev/null || true)"
+  fi
+  [[ -n "$num" ]] && printf '%s\n' "$num"
+}
+
+floor_review_count() {
+  command -v gh >/dev/null 2>&1 || { printf '%s\n' 0; return 0; }
+  [[ -n "${PR:-}" && -n "$OWNER" && -n "$REPO" ]] || { printf '%s\n' 0; return 0; }
+  gh pr view "$PR" -R "${OWNER}/${REPO}" --json reviews --template '{{len .reviews}}' 2>/dev/null || printf '%s\n' 0
 }
 
 floor_capture_pr() {
@@ -722,7 +741,7 @@ floor_dispatch() {
 }
 
 floor_next() {
-  local raw impl s lane pr qaurl="${URL:-${FACTORY_QA_URL:-}}"
+  local raw impl s lane pr nrev qaurl="${URL:-${FACTORY_QA_URL:-}}"
   raw="$(floor_mem)"
   for lane in feature bug docs qa review ci telemetry; do
     s="$(printf '%s\n' "$raw" | latest_lane_status "$lane")"
@@ -734,7 +753,7 @@ floor_next() {
   impl="$(floor_classify)"
   if [[ "$impl" == bug ]]; then
     s="$(printf '%s\n' "$raw" | latest_lane_status telemetry)"
-    if [[ -z "$s" ]]; then
+    if [[ -z "$s" && -z "${FLOOR_DID_TEL:-}" ]]; then
       printf '%s\n' telemetry
       return 0
     fi
@@ -747,33 +766,40 @@ floor_next() {
   fi
   PR="$pr"
   s="$(printf '%s\n' "$raw" | latest_lane_status qa)"
-  if [[ -z "$s" ]]; then
-    if [[ -n "$qaurl" ]]; then
+  if [[ -n "$qaurl" ]]; then
+    if [[ -z "$s" && -z "${FLOOR_DID_QA:-}" ]]; then
       printf '%s\n' qa
-    else
-      printf '%s\n' skip-qa
+      return 0
     fi
-    return 0
+  else
+    if [[ -z "$s" && -z "${FLOOR_QA_SKIPPED:-}" ]]; then
+      printf '%s\n' skip-qa
+      return 0
+    fi
   fi
-  s="$(printf '%s\n' "$raw" | latest_lane_status review)"
-  if [[ -z "$s" ]]; then
+  nrev="$(floor_review_count)"
+  if [[ "${nrev:-0}" -eq 0 && -z "${FLOOR_DID_REVIEW:-}" ]]; then
     printf '%s\n' review
-    return 0
-  fi
-  s="$(printf '%s\n' "$raw" | latest_lane_status ci)"
-  if [[ -z "$s" ]]; then
-    printf '%s\n' ci
     return 0
   fi
   if command -v gh >/dev/null 2>&1 && gh pr checks "$PR" -R "${OWNER}/${REPO}" >/dev/null 2>&1; then
     printf '%s\n' merge
-  else
-    printf '%s\n' stop:failed
+    return 0
   fi
+  if [[ -n "${FLOOR_DID_CI:-}" ]]; then
+    printf '%s\n' stop:failed
+    return 0
+  fi
+  printf '%s\n' ci
 }
 
 floor_run() {
   local next i
+  FLOOR_QA_SKIPPED=""
+  FLOOR_DID_QA=""
+  FLOOR_DID_REVIEW=""
+  FLOOR_DID_CI=""
+  FLOOR_DID_TEL=""
   need_issue
   [[ -n "$REPO" ]] || { echo "Need --repo <name>" >&2; exit 1; }
   need_owner
@@ -793,6 +819,7 @@ floor_run() {
         return 0
         ;;
       skip-qa)
+        FLOOR_QA_SKIPPED=1
         FACTORY_SKIP_TICKET_COMMENT=1 "$FACTORY/factory.sh" mem write \
           --lane qa --status done --harness "$RUNNER" --issue "$ISSUE" ${PR:+--pr "$PR"} \
           ${OWNER:+--owner "$OWNER"} ${REPO:+--repo "$REPO"} \
@@ -811,6 +838,10 @@ floor_run() {
               *) floor_capture_pr "$next" ;;
             esac
             ;;
+          qa) FLOOR_DID_QA=1 ;;
+          review) FLOOR_DID_REVIEW=1 ;;
+          ci) FLOOR_DID_CI=1 ;;
+          telemetry) FLOOR_DID_TEL=1 ;;
         esac
         ;;
       *)

--- a/factory.sh
+++ b/factory.sh
@@ -11,7 +11,7 @@ usage() {
 Usage:
   factory.sh feature|bug|docs --repo <name> --issue <n> [--owner org] [--runner grok|claude|codex] [--yes]
   factory.sh review|ci        --repo <name> --pr <n>     [--owner org] [--runner ...] [--yes]
-  factory.sh ship             --repo <name> --issue <n> --pr <n> [--yes]
+  factory.sh floor|ship       --repo <name> --issue <n> [--owner org] [--runner ...] [--yes] [--url <app>]
   factory.sh lead             --issue <n> [--repo <name>] [--yes]
   factory.sh telemetry        --question "<what broke>" [--yes]
   factory.sh qa               --repo <name> --pr <n> [--url <app>]
@@ -637,6 +637,192 @@ run_mem_lane() {
   return "$code"
 }
 
+floor_classify() {
+  local labels=""
+  if command -v gh >/dev/null 2>&1 && [[ -n "$OWNER" && -n "$REPO" ]]; then
+    labels="$(gh issue view "$ISSUE" -R "${OWNER}/${REPO}" --json labels 2>/dev/null || true)"
+  fi
+  case "$labels" in
+    *'"bug"'*|*'name": "bug'*|*[Bb]ug*) printf '%s\n' bug ;;
+    *documentation*|*docs*) printf '%s\n' docs ;;
+    *) printf '%s\n' feature ;;
+  esac
+}
+
+floor_mem() {
+  "$FACTORY/factory.sh" mem read --issue "$ISSUE" 2>/dev/null || true
+}
+
+floor_pr_from_mem() {
+  local line val
+  while IFS= read -r line; do
+    case "$line" in
+      *"pr = "*)
+        val="${line##* = }"
+        if [[ -n "$val" ]]; then
+          printf '%s\n' "$val"
+          return 0
+        fi
+        ;;
+    esac
+  done <<< "$(floor_mem)"
+}
+
+floor_pr_from_gh() {
+  local num title
+  command -v gh >/dev/null 2>&1 || return 0
+  [[ -n "$OWNER" && -n "$REPO" ]] || return 0
+  while IFS=$'\t' read -r num title; do
+    case "$title" in
+      */"$ISSUE"/*)
+        printf '%s\n' "$num"
+        return 0
+        ;;
+    esac
+  done < <(gh pr list -R "${OWNER}/${REPO}" --state open --json number,title --template '{{range .}}{{.number}}	{{.title}}{{"\n"}}{{end}}' 2>/dev/null || true)
+}
+
+floor_capture_pr() {
+  local lane="$1" num
+  num="$(floor_pr_from_mem)"
+  [[ -n "$num" ]] || num="$(floor_pr_from_gh)"
+  [[ -n "$num" ]] || return 0
+  PR="$num"
+  FACTORY_SKIP_TICKET_COMMENT=1 "$FACTORY/factory.sh" mem write \
+    --lane "$lane" --status done --harness "$RUNNER" --issue "$ISSUE" --pr "$num" \
+    ${OWNER:+--owner "$OWNER"} ${REPO:+--repo "$REPO"} \
+    --summary "Opened PR ${num}." --next-steps "QA, review, CI" >/dev/null 2>/dev/null || true
+}
+
+floor_cmd() {
+  if [[ "$YES" -eq 1 ]]; then
+    "$FACTORY/factory.sh" "$@" --yes
+  else
+    "$FACTORY/factory.sh" "$@"
+  fi
+}
+
+floor_dispatch() {
+  local lane="$1" qaurl="${URL:-${FACTORY_QA_URL:-}}"
+  echo "dispatch $lane"
+  case "$lane" in
+    feature|bug|docs)
+      floor_cmd "$lane" --repo "$REPO" --issue "$ISSUE" --owner "$OWNER" --runner "$RUNNER"
+      ;;
+    review|ci)
+      floor_cmd "$lane" --repo "$REPO" --pr "$PR" --issue "$ISSUE" --owner "$OWNER" --runner "$RUNNER"
+      ;;
+    qa)
+      floor_cmd qa --repo "$REPO" --pr "$PR" --issue "$ISSUE" --url "$qaurl" --owner "$OWNER" --runner "$RUNNER"
+      ;;
+    telemetry)
+      floor_cmd telemetry --question "evidence for issue ${ISSUE}" --repo "$REPO" --owner "$OWNER" --runner "$RUNNER"
+      ;;
+  esac
+}
+
+floor_next() {
+  local raw impl s lane pr qaurl="${URL:-${FACTORY_QA_URL:-}}"
+  raw="$(floor_mem)"
+  for lane in feature bug docs qa review ci telemetry; do
+    s="$(printf '%s\n' "$raw" | latest_lane_status "$lane")"
+    case "$s" in
+      blocked) printf '%s\n' stop:blocked; return 0 ;;
+      failed) printf '%s\n' stop:failed; return 0 ;;
+    esac
+  done
+  impl="$(floor_classify)"
+  if [[ "$impl" == bug ]]; then
+    s="$(printf '%s\n' "$raw" | latest_lane_status telemetry)"
+    if [[ -z "$s" ]]; then
+      printf '%s\n' telemetry
+      return 0
+    fi
+  fi
+  pr="$(floor_pr_from_mem)"
+  [[ -n "$pr" ]] || pr="$(floor_pr_from_gh)"
+  if [[ -z "$pr" ]]; then
+    printf '%s\n' "$impl"
+    return 0
+  fi
+  PR="$pr"
+  s="$(printf '%s\n' "$raw" | latest_lane_status qa)"
+  if [[ -z "$s" ]]; then
+    if [[ -n "$qaurl" ]]; then
+      printf '%s\n' qa
+    else
+      printf '%s\n' skip-qa
+    fi
+    return 0
+  fi
+  s="$(printf '%s\n' "$raw" | latest_lane_status review)"
+  if [[ -z "$s" ]]; then
+    printf '%s\n' review
+    return 0
+  fi
+  s="$(printf '%s\n' "$raw" | latest_lane_status ci)"
+  if [[ -z "$s" ]]; then
+    printf '%s\n' ci
+    return 0
+  fi
+  if command -v gh >/dev/null 2>&1 && gh pr checks "$PR" -R "${OWNER}/${REPO}" >/dev/null 2>&1; then
+    printf '%s\n' merge
+  else
+    printf '%s\n' stop:failed
+  fi
+}
+
+floor_run() {
+  local next i
+  need_issue
+  [[ -n "$REPO" ]] || { echo "Need --repo <name>" >&2; exit 1; }
+  need_owner
+  for i in 1 2 3 4 5 6 7 8; do
+    next="$(floor_next)"
+    case "$next" in
+      stop:blocked)
+        echo "blocked. stop."
+        return 0
+        ;;
+      stop:failed)
+        echo "failed. stop."
+        return 1
+        ;;
+      merge)
+        echo "a person merges. $(pr_url "$PR")"
+        return 0
+        ;;
+      skip-qa)
+        FACTORY_SKIP_TICKET_COMMENT=1 "$FACTORY/factory.sh" mem write \
+          --lane qa --status done --harness "$RUNNER" --issue "$ISSUE" ${PR:+--pr "$PR"} \
+          ${OWNER:+--owner "$OWNER"} ${REPO:+--repo "$REPO"} \
+          --summary "QA skipped, no URL." --next-steps "Review the PR" >/dev/null 2>/dev/null || true
+        continue
+        ;;
+      feature|bug|docs|qa|review|ci|telemetry)
+        set +e
+        floor_dispatch "$next"
+        set -e
+        case "$next" in
+          feature|bug|docs)
+            s="$(printf '%s\n' "$(floor_mem)" | latest_lane_status "$next")"
+            case "$s" in
+              blocked|failed) ;;
+              *) floor_capture_pr "$next" ;;
+            esac
+            ;;
+        esac
+        ;;
+      *)
+        echo "floor: unknown next $next" >&2
+        return 1
+        ;;
+    esac
+  done
+  echo "floor: too many steps" >&2
+  return 1
+}
+
 case "$LANE" in
   mem)
     case "$MEM_CMD" in
@@ -670,16 +856,9 @@ case "$LANE" in
     gh pr checks "$PR" -R "${OWNER}/${REPO}" || true
     exit "$code"
     ;;
-  ship)
-    need_issue
-    "$0" feature --repo "$REPO" --issue "$ISSUE" --owner "$OWNER" --runner "$RUNNER" "${YESFLAG[@]}"
-    if [[ -z "$PR" ]]; then
-      echo "Implement finished. Pass --pr <n> to continue into review+CI."
-      exit 0
-    fi
-    "$0" review --repo "$REPO" --pr "$PR" --owner "$OWNER" --runner "$RUNNER" "${YESFLAG[@]}"
-    "$0" ci --repo "$REPO" --pr "$PR" --owner "$OWNER" --runner "$RUNNER" "${YESFLAG[@]}"
-    echo "Ship lane done. A person merges. $(pr_url "$PR")"
+  floor|ship)
+    floor_run
+    exit $?
     ;;
   lead|tech-lead|cto)
     need_issue

--- a/tests/floor.sh
+++ b/tests/floor.sh
@@ -16,7 +16,11 @@ if grep -q "Ship lane done" "$FACTORY"; then
 fi
 fn="$(awk '/^floor_run\(\)/{on=1} on{print} on && /^}$/{exit}' "$FACTORY")"
 echo "$fn" | grep -q run_agent && fail "floor must not call run_agent"
-grep -q "gh pr list" "$FACTORY" || fail "PR capture should use gh pr list, not runner stdout"
+grep -q "gh pr view" "$FACTORY" || fail "PR capture should use gh pr view, not runner stdout"
+if grep -q '*\[Bb\]ug\*' "$FACTORY"; then
+  fail "classify must not glob raw JSON for bug"
+fi
+grep -q -- "--template" "$FACTORY" || fail "classify and pr view should use gh --template"
 
 WS="$TMP/workspace"
 mkdir -p "$WS/widgets"
@@ -39,20 +43,24 @@ cat > "$TMP/bin/gh" << 'EOF'
 #!/usr/bin/env bash
 dump="${FAKE_DUMP:?}"
 printf '%s\n' "$*" >> "$dump/gh"
+n=0
+if [[ -f "$dump/dispatched" ]]; then
+  n="$(wc -l < "$dump/dispatched" | tr -d ' ')"
+fi
 case "$1 $2" in
   "issue view")
-    printf '%s\n' '{"labels":[{"name":"ready-for-agent"},{"name":"enhancement"}]}'
+    printf '%s\n' 'ready-for-agent'
+    printf '%s\n' 'enhancement'
     ;;
-  "pr list")
-    if [[ -f "$dump/after-feature" ]]; then
-      printf '%s\n' $'40\tFeat/12/widgets'
+  "pr view")
+    if [[ "$*" == *reviews* ]]; then
+      if [[ "$n" -ge 2 ]]; then printf '%s\n' 1; else printf '%s\n' 0; fi
+    else
+      if [[ -f "$dump/after-feature" ]]; then printf '%s\n' 40; fi
     fi
     ;;
   "pr checks")
-    exit "${GH_CHECKS:-0}"
-    ;;
-  "pr view")
-    printf '%s\n' '40'
+    if [[ "$n" -ge 3 ]]; then exit 0; else exit 1; fi
     ;;
 esac
 exit 0
@@ -81,8 +89,10 @@ if grep -q "dispatch qa" "$TMP/out"; then
 fi
 grep -q "a person merges" "$TMP/out" || fail "floor should stop at human merge: $(cat "$TMP/out")"
 grep -q "pull/40" "$TMP/out" || fail "merge line should include PR URL: $(cat "$TMP/out")"
-pr="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT pr FROM runs WHERE issue = '12' AND pr IS NOT NULL AND pr != '' ORDER BY id DESC LIMIT 1;")"
+pr="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT pr FROM runs WHERE issue = '12' AND lane = 'feature' ORDER BY id DESC LIMIT 1;")"
 [[ "$pr" == "40" ]] || fail "memory should have pr=40 after feature, got $pr"
+fcount="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE issue = '12' AND lane = 'feature';")"
+[[ "$fcount" == "1" ]] || fail "pr should land on the feature run, not a second row, count=$fcount"
 
 # Blocked implement stops. No review or CI.
 rm -rf "$DUMP" "$TMP/memory"
@@ -106,5 +116,23 @@ mkdir -p "$DUMP"
 PATH="$TMP/bin:$PATH" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_OWNER=acme FACTORY_RUNNER=grok \
   "$FACTORY" ship --repo widgets --issue 12 >"$TMP/sout" 2>"$TMP/serr"
 grep -q "a person merges" "$TMP/sout" || fail "ship should run the floor: $(cat "$TMP/sout")"
+
+# Missing sqlite: GitHub still drives Feature → Review → CI
+hid="$TMP/nosqlite"
+mkdir -p "$hid"
+for cmd in bash mkdir date sed git grep dirname cat rm mktemp printf tr wc; do
+  src="$(command -v "$cmd" || true)"
+  [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
+done
+cp "$TMP/bin/grok" "$hid/grok"
+cp "$TMP/bin/gh" "$hid/gh"
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+PATH="$hid" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_OWNER=acme FACTORY_RUNNER=grok \
+  "$FACTORY" floor --repo widgets --issue 12 >"$TMP/nout" 2>"$TMP/nerr"
+grep -q "dispatch feature" "$TMP/nout" || fail "no-sqlite should dispatch feature: $(cat "$TMP/nout")"
+grep -q "dispatch review" "$TMP/nout" || fail "no-sqlite should dispatch review: $(cat "$TMP/nout")"
+grep -q "dispatch ci" "$TMP/nout" || fail "no-sqlite should dispatch ci: $(cat "$TMP/nout")"
+grep -q "a person merges" "$TMP/nout" || fail "no-sqlite should still merge from GitHub: $(cat "$TMP/nout") err=$(cat "$TMP/nerr")"
 
 echo "ok floor"

--- a/tests/floor.sh
+++ b/tests/floor.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+grep -q "factory.sh floor" "$FACTORY" || fail "usage should list floor"
+if grep -q "Ship lane done" "$FACTORY"; then
+  fail "ship should be an alias of floor, not the old chain"
+fi
+fn="$(awk '/^floor_run\(\)/{on=1} on{print} on && /^}$/{exit}' "$FACTORY")"
+echo "$fn" | grep -q run_agent && fail "floor must not call run_agent"
+grep -q "gh pr list" "$FACTORY" || fail "PR capture should use gh pr list, not runner stdout"
+
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
+DUMP="$TMP/dump"
+mkdir -p "$DUMP" "$TMP/bin"
+
+cat > "$TMP/bin/grok" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+: > "$dump/after-feature"
+printf 'grok\n' >> "$dump/dispatched"
+exit "${GROK_EXIT:-0}"
+EOF
+chmod +x "$TMP/bin/grok"
+
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/gh"
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' '{"labels":[{"name":"ready-for-agent"},{"name":"enhancement"}]}'
+    ;;
+  "pr list")
+    if [[ -f "$dump/after-feature" ]]; then
+      printf '%s\n' $'40\tFeat/12/widgets'
+    fi
+    ;;
+  "pr checks")
+    exit "${GH_CHECKS:-0}"
+    ;;
+  "pr view")
+    printf '%s\n' '40'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+
+run_floor() {
+  PATH="$TMP/bin:$PATH" \
+    FAKE_DUMP="$DUMP" \
+    FACTORY_SH="$FACTORY" \
+    FACTORY_WORKSPACE="$WS" \
+    FACTORY_OWNER=acme \
+    FACTORY_RUNNER=grok \
+    "$FACTORY" floor --repo widgets --issue 12 "$@"
+}
+
+# Feature → Review → CI, PR captured, person merges
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+run_floor >"$TMP/out" 2>"$TMP/err"
+grep -q "dispatch feature" "$TMP/out" || fail "floor should dispatch feature: $(cat "$TMP/out")"
+grep -q "dispatch review" "$TMP/out" || fail "floor should dispatch review: $(cat "$TMP/out")"
+grep -q "dispatch ci" "$TMP/out" || fail "floor should dispatch ci: $(cat "$TMP/out")"
+if grep -q "dispatch qa" "$TMP/out"; then
+  fail "no QA URL should skip qa process: $(cat "$TMP/out")"
+fi
+grep -q "a person merges" "$TMP/out" || fail "floor should stop at human merge: $(cat "$TMP/out")"
+grep -q "pull/40" "$TMP/out" || fail "merge line should include PR URL: $(cat "$TMP/out")"
+pr="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT pr FROM runs WHERE issue = '12' AND pr IS NOT NULL AND pr != '' ORDER BY id DESC LIMIT 1;")"
+[[ "$pr" == "40" ]] || fail "memory should have pr=40 after feature, got $pr"
+
+# Blocked implement stops. No review or CI.
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+GROK_EXIT=1 run_floor >"$TMP/bout" 2>"$TMP/berr" || true
+grep -q "dispatch feature" "$TMP/bout" || fail "blocked path should still dispatch feature"
+if grep -q "dispatch review" "$TMP/bout"; then
+  fail "blocked must not dispatch review: $(cat "$TMP/bout")"
+fi
+if grep -q "dispatch ci" "$TMP/bout"; then
+  fail "blocked must not dispatch ci: $(cat "$TMP/bout")"
+fi
+grep -q "blocked\|failed" "$TMP/bout" || fail "blocked path should stop: $(cat "$TMP/bout")"
+if grep -q "a person merges" "$TMP/bout"; then
+  fail "blocked must not ask a person to merge: $(cat "$TMP/bout")"
+fi
+
+# ship is floor
+rm -rf "$DUMP" "$TMP/memory"
+mkdir -p "$DUMP"
+PATH="$TMP/bin:$PATH" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_OWNER=acme FACTORY_RUNNER=grok \
+  "$FACTORY" ship --repo widgets --issue 12 >"$TMP/sout" 2>"$TMP/serr"
+grep -q "a person merges" "$TMP/sout" || fail "ship should run the floor: $(cat "$TMP/sout")"
+
+echo "ok floor"


### PR DESCRIPTION
`factory.sh floor` reads memory and GitHub, then dispatches one isolated lane at a time until a person should merge, or a lane is blocked or failed. After Feature/Bug/Docs it records the PR from `gh pr list`, not runner stdout. `ship` is now an alias of `floor`. References Kripu77/software-factory#12.