### PR TITLE
Feat/13/lead dispatches only through factory.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Use glossary terms from `CONTEXT.md`. Do not invent synonyms. Missing `CONTEXT.m
 
 ## Lanes
 
-- Tech lead: classify, quiz, ticket, dispatch one lane. Lanes report back. Dispatch the next. Do not implement.
+- Tech lead: classify, quiz, ticket, dispatch via factory.sh (usually floor). Lanes report back. Do not implement. Implementing in the lead session is a failed run.
 - Telemetry: evidence only. Report back to Tech lead. Do not implement. Do not classify.
 - Feature: do not expand the ask. Report back to Tech lead when the PR exists.
 - Bug: browser-repro if web, then TDD. Read factory memory at start. Write started if none in progress, then done, blocked, or failed. Report back to Tech lead.

--- a/commands/lead.md
+++ b/commands/lead.md
@@ -6,3 +6,5 @@ description: Tech lead: classify, quiz, ticket on the owning repo, dispatch. Do 
 Read `lanes/tech-lead.md` and `AGENTS.md`. Follow /to-tickets. Ask Telemetry when production data exists. Do not implement. Do not merge.
 
 At start, factory.sh mem read for this issue (or project if no issue). Empty memory is fine. Memory is a hint. GitHub is the source of truth when this laptop has no rows.
+
+After tickets exist, start factory.sh floor (or one factory.sh lane). Dispatch is factory.sh only. Implementing, reviewing, or watching CI in this session is a failed run. Cursor is a floor door, not a factory.sh --runner, unless a Cursor CLI exists. Workers use --runner on PATH.

--- a/factory.sh
+++ b/factory.sh
@@ -894,7 +894,7 @@ case "$LANE" in
   lead|tech-lead|cto)
     need_issue
     mem_read_context
-    prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}."
+    prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}. After tickets exist, start factory.sh floor --repo ${REPO:-<repo>} --issue ${ISSUE} (or one factory.sh lane). Dispatch is factory.sh only. Writing product code, leaving a review, or watching CI in this session is a failed run."
     if [[ -n "${MEM_CONTEXT:-}" ]]; then
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
     fi

--- a/factory.sh
+++ b/factory.sh
@@ -123,17 +123,17 @@ run_agent() {
     grok)
       local extra=(--no-auto-update --no-alt-screen)
       [[ "$YES" -eq 1 ]] && extra+=(--always-approve)
-      ( cd "$cwd" && grok "${extra[@]}" --rules "$rules" -p "$prompt" )
+      ( cd "$cwd" && FACTORY_LANE="$LANE" grok "${extra[@]}" --rules "$rules" -p "$prompt" )
       ;;
     claude)
       local extra=(-p --append-system-prompt "$rules")
       [[ "$YES" -eq 1 ]] && extra+=(--dangerously-skip-permissions)
-      ( cd "$cwd" && claude "${extra[@]}" "$prompt" )
+      ( cd "$cwd" && FACTORY_LANE="$LANE" claude "${extra[@]}" "$prompt" )
       ;;
     codex)
       local extra=(exec)
       [[ "$YES" -eq 1 ]] && extra+=(--full-auto)
-      ( cd "$cwd" && codex "${extra[@]}" "$prompt"$'\n\n'"$rules" )
+      ( cd "$cwd" && FACTORY_LANE="$LANE" codex "${extra[@]}" "$prompt"$'\n\n'"$rules" )
       ;;
     *)
       echo "Unknown runner: $RUNNER (grok|claude|codex)" >&2
@@ -680,6 +680,7 @@ floor_pr_from_mem() {
         ;;
     esac
   done <<< "$(floor_mem)"
+  return 0
 }
 
 floor_pr_from_gh() {
@@ -693,6 +694,7 @@ floor_pr_from_gh() {
     num="$(gh pr view -R "${OWNER}/${REPO}" --json number --template '{{.number}}' 2>/dev/null || true)"
   fi
   [[ -n "$num" ]] && printf '%s\n' "$num"
+  return 0
 }
 
 floor_review_count() {
@@ -804,6 +806,9 @@ floor_run() {
   [[ -n "$REPO" ]] || { echo "Need --repo <name>" >&2; exit 1; }
   need_owner
   for i in 1 2 3 4 5 6 7 8; do
+    pr="$(floor_pr_from_mem)"
+    [[ -n "$pr" ]] || pr="$(floor_pr_from_gh)"
+    [[ -n "$pr" ]] && PR="$pr"
     next="$(floor_next)"
     case "$next" in
       stop:blocked)
@@ -899,6 +904,11 @@ case "$LANE" in
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
     fi
     run_agent "$WORKSPACE" "$(cat "$FACTORY/lanes/tech-lead.md")"$'\n'"$HARD" "$prompt"
+    if [[ -n "${REPO:-}" && -n "${OWNER:-}" ]]; then
+      echo "dispatch factory.sh floor"
+      floor_cmd floor --repo "$REPO" --issue "$ISSUE" --owner "$OWNER" --runner "$RUNNER"
+      exit $?
+    fi
     ;;
   telemetry)
     need_question

--- a/lanes/tech-lead.md
+++ b/lanes/tech-lead.md
@@ -2,9 +2,11 @@ You are the factory Tech lead.
 
 Before classifying or dispatching, run factory.sh mem read for this issue (or project if no issue) and put those rows in context. Empty memory is fine. GitHub is the source of truth when this laptop has no rows. Memory is a hint, not a lock.
 
-Classify as bug, feature, or docs. Quiz the human on tracer-bullet slices, then publish GitHub issues on the owning repo with ready-for-agent. Dispatch one lane. Do not implement. Do not merge.
+Classify as bug, feature, or docs. Quiz the human on tracer-bullet slices, then publish GitHub issues on the owning repo with ready-for-agent.
+
+Dispatch only by running factory.sh (usually factory.sh floor, or one factory.sh lane). Writing product code, leaving a review, or watching CI in this session is a failed run. Do not implement. Do not merge.
 
 Ask Telemetry for evidence before a Bug dispatch when production data exists.
 Ask Telemetry when the work might be drop-off or a feature that is not performing (any path, not only signup). Telemetry reports; you classify.
 
-Lanes report back to you when their job is done. You dispatch the next one (QA, Review, CI, or the human to merge). Do not let a lane chain itself forward.
+Lanes report back to you when their job is done. You dispatch the next one by running factory.sh again. Do not let a lane chain itself forward.

--- a/tests/lead.sh
+++ b/tests/lead.sh
@@ -45,10 +45,16 @@ run_lead() {
 need_text lanes/tech-lead.md "mem read"
 need_text lanes/tech-lead.md "hint"
 need_text lanes/tech-lead.md "Do not implement"
-need_text lanes/tech-lead.md "Dispatch"
+need_text lanes/tech-lead.md "factory.sh"
+need_text lanes/tech-lead.md "floor"
+need_text lanes/tech-lead.md "failed run"
 need_text lanes/tech-lead.md "Do not let a lane chain"
 need_text commands/lead.md "mem read"
 need_text commands/lead.md "Do not implement"
+need_text commands/lead.md "factory.sh"
+need_text commands/lead.md "floor"
+need_text commands/lead.md "failed run"
+need_text commands/lead.md "Cursor"
 
 # Missing DB: warn once, lead still runs, no write
 rm -rf "$DUMP" "$TMP/memory"
@@ -74,6 +80,8 @@ grep -q "acme/widgets" "$DUMP/prompt" || fail "lead prompt missing project: $(ca
 grep -q "status = done" "$DUMP/prompt" || fail "lead prompt missing status: $(cat "$DUMP/prompt")"
 grep -q "Add widgets list" "$DUMP/prompt" || fail "lead prompt missing summary: $(cat "$DUMP/prompt")"
 grep -q "QA the PR" "$DUMP/prompt" || fail "lead prompt missing next_steps: $(cat "$DUMP/prompt")"
+grep -q "factory.sh floor" "$DUMP/prompt" || fail "lead prompt must start floor via factory.sh: $(cat "$DUMP/prompt")"
+grep -q "failed run" "$DUMP/prompt" || fail "lead prompt must call implementing a failed run: $(cat "$DUMP/prompt")"
 after="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
 [[ "$before" == "$after" ]] || fail "lead must not write runs, before=$before after=$after"
 

--- a/tests/lead.sh
+++ b/tests/lead.sh
@@ -15,33 +15,91 @@ need_text() {
   grep -q "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
 }
 
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
 DUMP="$TMP/dump"
-mkdir -p "$DUMP" "$TMP/bin" "$TMP/workspace"
+mkdir -p "$DUMP" "$TMP/bin"
 
 cat > "$TMP/bin/grok" << 'EOF'
 #!/usr/bin/env bash
 dump="${FAKE_DUMP:?}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -p) printf '%s\n' "$2" > "$dump/prompt"; shift 2 ;;
-    --rules) printf '%s\n' "$2" > "$dump/rules"; shift 2 ;;
+    -p)
+      if [[ ! -f "$dump/prompt" ]]; then
+        printf '%s\n' "$2" > "$dump/prompt"
+      fi
+      shift 2
+      ;;
+    --rules)
+      if [[ ! -f "$dump/rules" ]]; then
+        printf '%s\n' "$2" > "$dump/rules"
+      fi
+      shift 2
+      ;;
     *) shift ;;
   esac
 done
 : > "$dump/ran"
+case "${FACTORY_LANE:-}" in
+  feature|bug|docs)
+    : > "$dump/after-feature"
+    printf 'grok\n' >> "$dump/dispatched"
+    ;;
+  review)
+    : > "$dump/after-review"
+    printf 'grok\n' >> "$dump/dispatched"
+    ;;
+  ci)
+    : > "$dump/after-ci"
+    printf 'grok\n' >> "$dump/dispatched"
+    ;;
+esac
+exit "${GROK_EXIT:-0}"
 EOF
 chmod +x "$TMP/bin/grok"
+
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/gh"
+n=0
+if [[ -f "$dump/dispatched" ]]; then
+  n="$(wc -l < "$dump/dispatched" | tr -d ' ')"
+fi
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' 'ready-for-agent'
+    printf '%s\n' 'enhancement'
+    ;;
+  "pr view")
+    if [[ "$*" == *reviews* ]]; then
+      if [[ -f "$dump/after-review" ]]; then printf '%s\n' 1; else printf '%s\n' 0; fi
+    else
+      if [[ -f "$dump/after-feature" ]]; then printf '%s\n' 40; fi
+    fi
+    ;;
+  "pr checks")
+    if [[ -f "$dump/after-ci" ]]; then exit 0; else exit 1; fi
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
 
 run_lead() {
   PATH="$TMP/bin:$PATH" \
     FAKE_DUMP="$DUMP" \
-    FACTORY_WORKSPACE="$TMP/workspace" \
+    FACTORY_SH="$FACTORY" \
+    FACTORY_WORKSPACE="$WS" \
     FACTORY_OWNER=acme \
     FACTORY_RUNNER=grok \
     "$FACTORY" lead --issue 7 --repo widgets
 }
 
-# Lane and /lead command read memory, still dispatch, still do not implement
 need_text lanes/tech-lead.md "mem read"
 need_text lanes/tech-lead.md "hint"
 need_text lanes/tech-lead.md "Do not implement"
@@ -56,7 +114,7 @@ need_text commands/lead.md "floor"
 need_text commands/lead.md "failed run"
 need_text commands/lead.md "Cursor"
 
-# Missing DB: warn once, lead still runs, no write
+# Missing DB: lead still runs, then starts floor. Lead does not write a run.
 rm -rf "$DUMP" "$TMP/memory"
 mkdir -p "$DUMP"
 set +e
@@ -65,15 +123,18 @@ code=$?
 set -e
 [[ $code -eq 0 ]] || fail "missing db lead exit $code err=$(cat "$TMP/err")"
 [[ -f "$DUMP/ran" ]] || fail "missing db should still run lead"
+grep -q "dispatch factory.sh floor" "$TMP/out" || fail "lead should start floor: $(cat "$TMP/out")"
+grep -q "dispatch feature" "$TMP/out" || fail "floor after lead should dispatch feature: $(cat "$TMP/out")"
+grep -q "a person merges" "$TMP/out" || fail "floor after lead should reach merge: $(cat "$TMP/out")"
 warns="$(grep -c "factory.db\|factory memory" "$TMP/err" || true)"
-[[ "$warns" == "1" ]] || fail "missing db should warn once, got $warns: $(cat "$TMP/err")"
-[[ ! -f "$FACTORY_MEMORY_DB" ]] || fail "lead must not create memory on read"
+[[ "$warns" -ge 1 ]] || fail "missing db should warn, got $warns: $(cat "$TMP/err")"
+lead_rows="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE lane = 'lead';")"
+[[ "$lead_rows" == "0" ]] || fail "lead must not write runs, got $lead_rows"
 
-# Rows for the issue are in the prompt. Lead does not write a run.
-"$FACTORY" mem write --harness grok --project acme/widgets --lane feature --status done --issue 7 --pr 40 --summary "Add widgets list" --next-steps "QA the PR" --evidence "https://github.com/acme/widgets/pull/40" >/dev/null
-before="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
-rm -rf "$DUMP"
+# Rows for the issue are in the lead prompt.
+rm -rf "$DUMP" "$TMP/memory"
 mkdir -p "$DUMP"
+"$FACTORY" mem write --harness grok --project acme/widgets --lane feature --status done --issue 7 --pr 40 --summary "Add widgets list" --next-steps "QA the PR" --evidence "https://github.com/acme/widgets/pull/40" >/dev/null
 run_lead >"$TMP/out2" 2>"$TMP/err2"
 [[ -f "$DUMP/ran" ]] || fail "lead with rows should run"
 grep -q "acme/widgets" "$DUMP/prompt" || fail "lead prompt missing project: $(cat "$DUMP/prompt")"
@@ -82,34 +143,37 @@ grep -q "Add widgets list" "$DUMP/prompt" || fail "lead prompt missing summary: 
 grep -q "QA the PR" "$DUMP/prompt" || fail "lead prompt missing next_steps: $(cat "$DUMP/prompt")"
 grep -q "factory.sh floor" "$DUMP/prompt" || fail "lead prompt must start floor via factory.sh: $(cat "$DUMP/prompt")"
 grep -q "failed run" "$DUMP/prompt" || fail "lead prompt must call implementing a failed run: $(cat "$DUMP/prompt")"
-after="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs;")"
-[[ "$before" == "$after" ]] || fail "lead must not write runs, before=$before after=$after"
+lead_rows="$(sqlite3 "$FACTORY_MEMORY_DB" "SELECT COUNT(*) FROM runs WHERE lane = 'lead';")"
+[[ "$lead_rows" == "0" ]] || fail "lead must not write runs, got $lead_rows"
 
-# Issue rows from another project still reach lead. mem read is issue, not issue AND project.
+# Issue rows from another project still reach lead.
 rm -rf "$DUMP" "$TMP/memory"
 mkdir -p "$DUMP"
 "$FACTORY" mem write --harness grok --project other/repo --lane feature --status done --issue 7 --summary "Shipped on other remote" --evidence "https://github.com/other/repo/issues/7" >/dev/null
 run_lead >"$TMP/out3" 2>"$TMP/err3"
 grep -q "Shipped on other remote" "$DUMP/prompt" || fail "lead should see issue 7 from another project: $(cat "$DUMP/prompt")"
 
-# sqlite3 missing: warn once, lead still succeeds
+# sqlite3 missing: lead still starts floor; GitHub drives the table
 hid="$TMP/nosqlite"
 mkdir -p "$hid"
-for cmd in bash mkdir date sed git grep dirname cat rm mktemp printf; do
+for cmd in bash mkdir date sed git grep dirname cat rm mktemp printf tr wc; do
   src="$(command -v "$cmd" || true)"
   [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
 done
 cp "$TMP/bin/grok" "$hid/grok"
+cp "$TMP/bin/gh" "$hid/gh"
 rm -rf "$DUMP"
 mkdir -p "$DUMP"
 set +e
-PATH="$hid" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$TMP/workspace" FACTORY_OWNER=acme FACTORY_RUNNER=grok \
+PATH="$hid" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_OWNER=acme FACTORY_RUNNER=grok \
   "$FACTORY" lead --issue 7 --repo widgets >"$TMP/nout" 2>"$TMP/nerr"
 ncode=$?
 set -e
 [[ $ncode -eq 0 ]] || fail "missing sqlite3 should not fail lead, exit $ncode err=$(cat "$TMP/nerr")"
 [[ -f "$DUMP/ran" ]] || fail "missing sqlite3 should still run lead"
+grep -q "dispatch factory.sh floor" "$TMP/nout" || fail "missing sqlite3 should still start floor: $(cat "$TMP/nout")"
+grep -q "a person merges" "$TMP/nout" || fail "missing sqlite3 floor should still merge: $(cat "$TMP/nout") err=$(cat "$TMP/nerr")"
 nwarns="$(grep -c "factory.db\|factory memory\|sqlite3" "$TMP/nerr" || true)"
-[[ "$nwarns" == "1" ]] || fail "missing sqlite3 should warn once, got $nwarns: $(cat "$TMP/nerr")"
+[[ "$nwarns" -ge 1 ]] || fail "missing sqlite3 should warn, got $nwarns: $(cat "$TMP/nerr")"
 
 echo "ok lead"


### PR DESCRIPTION
`/lead` now dispatches only by running factory.sh floor, or one factory.sh lane. Implementing, reviewing, or watching CI in the lead session is a failed run. Cursor is a floor door, not a --runner. References Kripu77/software-factory#13.