### PR TITLE
Feat/one-command-setup: install then /lead in the product repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ cd software-factory
 ./install.sh
 ```
 
-Install creates `~/.factory/memory`. It does not touch other memory plugins.
+That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/.local/bin`. Then:
+
+```bash
+cd /path/to/your-checkout
+grok          # or claude
+/lead
+```
+
+Owner and repo come from `git remote`. Workspace is this directory. Put `~/.local/bin` on PATH if `factory` is missing. Two of claude, codex, grok on PATH: set `FACTORY_RUNNER`.
 
 | Harness | How it loads |
 | --- | --- |
@@ -62,13 +70,6 @@ Install creates `~/.factory/memory`. It does not touch other memory plugins.
 | Claude Code | skills + slash commands under `~/.claude` |
 | Grok Build | plugin at `~/.grok/plugins/software-factory` (`grok plugin install . --trust`) |
 | Codex | skills under `~/.codex/skills` plus `AGENTS.md` in the product checkout |
-
-Then:
-
-```bash
-export FACTORY_WORKSPACE=/path/to/your-checkout
-export FACTORY_OWNER=your-github-org
-```
 
 ## Run
 
@@ -110,7 +111,7 @@ A person still quizzes before tickets, logs in for a protected browser, and merg
 
 Telemetry adapters in this repo are vendor notes and a contract. They do not pull production data. `/telemetry` only works if the product checkout already has an adapter wired.
 
-We used these lanes to build this factory. That does not mean they have been walked on your app. Clone onto a repo you own, set `FACTORY_WORKSPACE` and `FACTORY_OWNER`, put one worker CLI on PATH or set `FACTORY_RUNNER`, run `/lead` or `factory.sh floor --repo <name> --issue <n>`, and you merge.
+We used these lanes to build this factory. That does not mean they have been walked on your app. `./install.sh`, cd into a repo you own, `/lead`, and you merge.
 
 `./install.sh` does not make every CLI a factory.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cd software-factory
 ./install.sh
 ```
 
-That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/.local/bin`. Then:
+That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/.local/bin`. Codex: `./install.sh /path/to/your-checkout` also writes `AGENTS.md` there. Then:
 
 ```bash
 cd /path/to/your-checkout

--- a/factory.sh
+++ b/factory.sh
@@ -123,12 +123,7 @@ infer_github() {
     url="$(git remote get-url origin 2>/dev/null || true)"
   fi
   [[ -n "$url" ]] || return 0
-  if owner_name "$url"; then
-    project="$url"
-  else
-    project="$(printf '%s' "$url" | sed -E -e 's#^[a-zA-Z0-9+.-]+://##' -e 's#^.*@##' -e 's#^[^:/]+(:[0-9]+)?[:/]##' -e 's#\.git$##' -e 's#/$##')"
-  fi
-  owner_name "$project" || return 0
+  project="$(github_owner_repo "$url")" || return 0
   [[ -n "$OWNER" ]] || OWNER="${project%%/*}"
   [[ -n "$REPO" ]] || REPO="${project##*/}"
 }
@@ -292,16 +287,21 @@ owner_name() {
   [[ "$1" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]
 }
 
-project_from_remote() {
-  local raw="$1"
-  local project
-  [[ -n "$raw" ]] || { echo "Need --project owner/name" >&2; exit 1; }
+github_owner_repo() {
+  local raw="$1" project
+  [[ -n "$raw" ]] || return 1
   if owner_name "$raw"; then
-    PROJECT="$raw"
-    return
+    printf '%s\n' "$raw"
+    return 0
   fi
   project="$(printf '%s' "$raw" | sed -E -e 's#^[a-zA-Z0-9+.-]+://##' -e 's#^.*@##' -e 's#^[^:/]+(:[0-9]+)?[:/]##' -e 's#\.git$##' -e 's#/$##')"
-  owner_name "$project" || { echo "Need --project owner/name" >&2; exit 1; }
+  owner_name "$project" || return 1
+  printf '%s\n' "$project"
+}
+
+project_from_remote() {
+  local project
+  project="$(github_owner_repo "$1")" || { echo "Need --project owner/name" >&2; exit 1; }
   PROJECT="$project"
 }
 

--- a/factory.sh
+++ b/factory.sh
@@ -20,7 +20,7 @@ Usage:
   factory.sh mem write        --lane <lane> --status started|done|blocked|failed [--harness claude|codex|cursor|grok] [--issue <n>] [--pr <n>] [--project owner/name] [--summary s] [--next-steps s] [--evidence url-or-json]
 
 Never merges. A person merges.
-FACTORY_WORKSPACE, FACTORY_OWNER, FACTORY_RUNNER can be set instead of flags.
+Workspace defaults to this directory. Owner and repo default from git remote origin. FACTORY_RUNNER if more than one of claude, codex, grok is on PATH.
 Memory: FACTORY_MEMORY_DB (default ~/.factory/memory/factory.db). Optional. Missing db warns and continues.
 EOF
   exit 1
@@ -115,7 +115,25 @@ else
   detect_runner
 fi
 
-need_owner() { [[ -n "$OWNER" ]] || { echo "Need --owner or FACTORY_OWNER" >&2; exit 1; }; }
+infer_github() {
+  [[ -n "$OWNER" && -n "$REPO" ]] && return 0
+  local url="" project=""
+  url="$(git -C "$WORKSPACE" remote get-url origin 2>/dev/null || true)"
+  if [[ -z "$url" ]]; then
+    url="$(git remote get-url origin 2>/dev/null || true)"
+  fi
+  [[ -n "$url" ]] || return 0
+  if owner_name "$url"; then
+    project="$url"
+  else
+    project="$(printf '%s' "$url" | sed -E -e 's#^[a-zA-Z0-9+.-]+://##' -e 's#^.*@##' -e 's#^[^:/]+(:[0-9]+)?[:/]##' -e 's#\.git$##' -e 's#/$##')"
+  fi
+  owner_name "$project" || return 0
+  [[ -n "$OWNER" ]] || OWNER="${project%%/*}"
+  [[ -n "$REPO" ]] || REPO="${project##*/}"
+}
+
+need_owner() { [[ -n "$OWNER" ]] || { echo "Need --owner, FACTORY_OWNER, or a github origin remote" >&2; exit 1; }; }
 need_issue() { [[ -n "$ISSUE" ]] || { echo "Need --issue <n>" >&2; exit 1; }; }
 need_pr() { [[ -n "$PR" ]] || { echo "Need --pr <n>" >&2; exit 1; }; }
 need_question() { [[ -n "$QUESTION" ]] || { echo "Need --question" >&2; exit 1; }; }
@@ -894,6 +912,8 @@ floor_run() {
   echo "floor: too many steps" >&2
   return 1
 }
+
+infer_github
 
 case "$LANE" in
   mem)

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,11 @@ echo "Factory: $FACTORY"
 mkdir -p "${HOME}/.factory/memory"
 echo "memory ${HOME}/.factory/memory"
 
+bindir="${HOME}/.local/bin"
+mkdir -p "$bindir"
+ln -sfn "$FACTORY/factory.sh" "$bindir/factory"
+echo "cli $bindir/factory"
+
 # Grok Build plugin (skills + commands). Copies into ~/.grok/installed-plugins.
 if command -v grok >/dev/null 2>&1; then
   if grok plugin list 2>/dev/null | grep -q "software-factory"; then
@@ -77,14 +82,13 @@ if [[ -n "$WORKSPACE" && -d "$WORKSPACE" ]]; then
     cp "$FACTORY/AGENTS.md" "$target"
     echo "wrote $target"
   fi
-else
-  echo "Set FACTORY_WORKSPACE to drop AGENTS.md into a product checkout (Codex and friends read it there)."
 fi
 
 echo
-echo "Cursor:  /feature /bug /review /ci /telemetry /lead /unslop /poteto-mode /qa"
-echo "Claude:  same slash commands after restart"
-echo "Grok:    grok plugin list, then /feature /unslop /poteto-mode /qa"
-echo "Codex:   AGENTS.md in the checkout"
-echo "CI door: $FACTORY/factory.sh lead --repo <name> --issue N"
+echo "Next: cd into the product repo, open grok (or claude), /lead"
+echo "Owner and repo come from git remote. Workspace is that directory."
+case ":${PATH}:" in
+  *":${HOME}/.local/bin:"*) ;;
+  *) echo "Put ${HOME}/.local/bin on PATH so \`factory lead\` works." ;;
+esac
 echo "If more than one of claude, codex, grok is on PATH, set FACTORY_RUNNER."

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ if [[ -d "${HOME}/.cursor" ]]; then
   echo "linked cursor plugin $dest"
 fi
 
-WORKSPACE="${FACTORY_WORKSPACE:-}"
+WORKSPACE="${1:-${FACTORY_WORKSPACE:-}}"
 if [[ -n "$WORKSPACE" && -d "$WORKSPACE" ]]; then
   target="$WORKSPACE/AGENTS.md"
   if [[ -f "$target" ]] && grep -q "Software factory" "$target"; then

--- a/tests/infer.sh
+++ b/tests/infer.sh
@@ -32,4 +32,11 @@ PATH="$TMP/bin:$PATH" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_RUNNER=r
 grep -q "Need --owner" "$TMP/err" && fail "should not demand FACTORY_OWNER when origin is github: $(cat "$TMP/err")"
 grep -q "Need --repo" "$TMP/err" && fail "should not demand --repo when origin is github: $(cat "$TMP/err")"
 
+rm -f "$DUMP/ran"
+git -C "$WS" remote set-url origin "git@github.com:acme/widgets.git"
+PATH="$TMP/bin:$PATH" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
+  "$FACTORY" feature --issue 13 >"$TMP/out2" 2>"$TMP/err2"
+[[ -f "$DUMP/ran" ]] || fail "should infer from git@github.com origin, err=$(cat "$TMP/err2")"
+grep -q "Need --owner" "$TMP/err2" && fail "ssh origin should not demand FACTORY_OWNER: $(cat "$TMP/err2")"
+
 echo "ok infer"

--- a/tests/infer.sh
+++ b/tests/infer.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_OWNER
+unset FACTORY_RUNNER
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WS="$TMP/widgets"
+mkdir -p "$WS"
+git -C "$WS" init -q
+git -C "$WS" remote add origin "https://github.com/acme/widgets.git"
+
+DUMP="$TMP/dump"
+mkdir -p "$DUMP" "$TMP/bin"
+cat > "$TMP/bin/runner" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+: > "$dump/ran"
+exit 0
+EOF
+chmod +x "$TMP/bin/runner"
+
+PATH="$TMP/bin:$PATH" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
+  "$FACTORY" feature --issue 12 >"$TMP/out" 2>"$TMP/err"
+[[ -f "$DUMP/ran" ]] || fail "should infer owner/repo from origin and run, err=$(cat "$TMP/err")"
+grep -q "Need --owner" "$TMP/err" && fail "should not demand FACTORY_OWNER when origin is github: $(cat "$TMP/err")"
+grep -q "Need --repo" "$TMP/err" && fail "should not demand --repo when origin is github: $(cat "$TMP/err")"
+
+echo "ok infer"

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -31,10 +31,11 @@ need_text factory.sh "mem write"
 need_text README.md "/lead"
 need_text README.md "~/.local/bin"
 need_text README.md "git remote"
+need_text README.md "AGENTS.md"
 
 hid="$TMP/bin"
 mkdir -p "$hid"
-for cmd in bash mkdir ln rm echo grep command cat; do
+for cmd in bash mkdir ln rm echo grep command cat cp; do
   src="$(command -v "$cmd" || true)"
   [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
 done
@@ -47,5 +48,11 @@ grep -q "memory " "$TMP/out" || fail "install should mention memory: $(cat "$TMP
 grep -qi "lead" "$TMP/out" || fail "install should tell you to /lead: $(cat "$TMP/out")"
 [[ ! -e "$TMP/.claude-mem" ]] || fail "install must not create other plugin dirs"
 [[ ! -e "$TMP/.cursor-mem" ]] || fail "install must not create other plugin dirs"
+
+prod="$TMP/product"
+mkdir -p "$prod"
+HOME="$TMP" PATH="$hid" "$ROOT/install.sh" "$prod" >"$TMP/out2" 2>"$TMP/err2" || fail "install with checkout exit $? err=$(cat "$TMP/err2")"
+[[ -f "$prod/AGENTS.md" ]] || fail "install.sh <checkout> should write AGENTS.md"
+grep -q "Software factory" "$prod/AGENTS.md" || fail "AGENTS.md should be the factory house rules"
 
 echo "ok install"

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -28,6 +28,9 @@ need_text rules/factory.mdc "attribute"
 need_text rules/factory.mdc ".env"
 need_text factory.sh "mem read"
 need_text factory.sh "mem write"
+need_text README.md "/lead"
+need_text README.md "~/.local/bin"
+need_text README.md "git remote"
 
 hid="$TMP/bin"
 mkdir -p "$hid"
@@ -38,7 +41,10 @@ done
 
 HOME="$TMP" PATH="$hid" "$ROOT/install.sh" >"$TMP/out" 2>"$TMP/err" || fail "install exit $? err=$(cat "$TMP/err")"
 [[ -d "$TMP/.factory/memory" ]] || fail "install should create ~/.factory/memory"
+[[ -L "$TMP/.local/bin/factory" ]] || fail "install should put factory on ~/.local/bin"
+[[ "$(readlink "$TMP/.local/bin/factory")" == "$ROOT/factory.sh" ]] || fail "factory symlink should point at factory.sh"
 grep -q "memory " "$TMP/out" || fail "install should mention memory: $(cat "$TMP/out")"
+grep -qi "lead" "$TMP/out" || fail "install should tell you to /lead: $(cat "$TMP/out")"
 [[ ! -e "$TMP/.claude-mem" ]] || fail "install must not create other plugin dirs"
 [[ ! -e "$TMP/.cursor-mem" ]] || fail "install must not create other plugin dirs"
 


### PR DESCRIPTION
`./install.sh` now puts `factory` on ~/.local/bin. Owner and repo come from git remote. Workspace is the directory you are in. README setup is clone, install, cd the product, /lead. You still merge.