### PR TITLE
Feat/28/version tags publish a GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: bash scripts/check-plugin-versions.sh "${GITHUB_REF_NAME}"
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --notes "Software factory ${GITHUB_REF_NAME}."

--- a/README.md
+++ b/README.md
@@ -54,13 +54,22 @@ cd software-factory
 ./install.sh
 ```
 
-That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/.local/bin`. Codex: `./install.sh /path/to/your-checkout` also writes `AGENTS.md` there. Then:
+Clone plus `./install.sh` is the from-source path. That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/.local/bin`. Codex: `./install.sh /path/to/your-checkout` also writes `AGENTS.md` there. Then:
 
 ```bash
 cd /path/to/your-checkout
 grok          # or claude
 /lead
 ```
+
+The versioned pack is on GitHub Releases. Set plugin versions in `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and `.grok-plugin/plugin.json` to the tag without the `v`, then:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+A person creates the tag. A push to main does not cut a Release.
 
 Owner and repo come from `git remote`. Workspace is this directory. Put `~/.local/bin` on PATH if `factory` is missing. Two of claude, codex, grok on PATH: set `FACTORY_RUNNER`.
 

--- a/scripts/check-plugin-versions.sh
+++ b/scripts/check-plugin-versions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+root="${2:-$(cd "$(dirname "$0")/.." && pwd)}"
+[[ -n "$tag" ]] || { echo "usage: check-plugin-versions.sh vX.Y.Z [root]" >&2; exit 1; }
+want="${tag#v}"
+
+plugin_version() {
+  awk -F'"' '/"version"/ { print $4; exit }' "$1"
+}
+
+for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json .grok-plugin/plugin.json; do
+  path="$root/$f"
+  [[ -f "$path" ]] || { echo "missing $f" >&2; exit 1; }
+  got="$(plugin_version "$path")"
+  [[ "$got" == "$want" ]] || { echo "$f version $got does not match $tag" >&2; exit 1; }
+done

--- a/scripts/check-plugin-versions.sh
+++ b/scripts/check-plugin-versions.sh
@@ -7,7 +7,7 @@ root="${2:-$(cd "$(dirname "$0")/.." && pwd)}"
 want="${tag#v}"
 
 plugin_version() {
-  awk -F'"' '/"version"/ { print $4; exit }' "$1"
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$1"
 }
 
 for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json .grok-plugin/plugin.json; do

--- a/tests/release.sh
+++ b/tests/release.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+check="$ROOT/scripts/check-plugin-versions.sh"
+[[ -x "$check" ]] || fail "missing executable scripts/check-plugin-versions.sh"
+
+"$check" v1.0.0 || fail "v1.0.0 should match plugin versions in this checkout"
+
+fx="$TMP/pack"
+mkdir -p "$fx/.claude-plugin" "$fx/.cursor-plugin" "$fx/.grok-plugin"
+for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json .grok-plugin/plugin.json; do
+  cp "$ROOT/$f" "$fx/$f"
+done
+"$check" v1.0.0 "$fx" || fail "fixture at 1.0.0 should pass v1.0.0"
+
+set +e
+"$check" v2.0.0 "$fx" >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -ne 0 ]] || fail "v2.0.0 should fail when plugins are 1.0.0"
+grep -q "1.0.0" "$TMP/err" || fail "mismatch should name the plugin version: $(cat "$TMP/err")"
+
+sed 's/"1.0.0"/"1.0.1"/' "$fx/.cursor-plugin/plugin.json" >"$TMP/cursor.json"
+mv "$TMP/cursor.json" "$fx/.cursor-plugin/plugin.json"
+set +e
+"$check" v1.0.0 "$fx" >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -ne 0 ]] || fail "one plugin off the tag should fail"
+cp "$ROOT/.cursor-plugin/plugin.json" "$fx/.cursor-plugin/plugin.json"
+
+rm "$fx/.grok-plugin/plugin.json"
+set +e
+"$check" v1.0.0 "$fx" >"$TMP/out" 2>"$TMP/err"
+code=$?
+set -e
+[[ $code -ne 0 ]] || fail "missing plugin.json should fail"
+
+rel="$ROOT/.github/workflows/release.yml"
+[[ -f "$rel" ]] || fail "missing .github/workflows/release.yml"
+grep -q "tags:" "$rel" || fail "release workflow should trigger on tags"
+grep -q "v\*\.\*\.\*" "$rel" || fail "release workflow should match vX.Y.Z tags"
+if grep -q "branches:" "$rel"; then
+  fail "release workflow must not run on branch pushes"
+fi
+if grep -q "pull_request" "$rel"; then
+  fail "release workflow must not run on pull_request"
+fi
+grep -q "ubuntu-latest" "$rel" || fail "should use GitHub-hosted ubuntu-latest"
+if grep -qi "self-hosted" "$rel"; then
+  fail "must use GitHub-hosted runners"
+fi
+grep -q "contents: write" "$rel" || fail "creating a Release needs contents: write"
+grep -q "gh release create" "$rel" || fail "should create a GitHub Release with gh release create"
+if grep -q "gh pr merge" "$rel" || grep -q "gh merge" "$rel"; then
+  fail "workflow must not merge"
+fi
+if grep -q "\.env" "$rel"; then
+  fail "workflow must not touch .env"
+fi
+if grep -qi "secrets" "$rel"; then
+  fail "workflow must not use secrets"
+fi
+if grep -E -- "--notes[[:space:]]+\"\"" "$rel"; then
+  fail "Release notes must be non-empty"
+fi
+if ! grep -q -- "--notes" "$rel" && ! grep -q -- "--generate-notes" "$rel"; then
+  fail "Release notes must be non-empty"
+fi
+grep -q "check-plugin-versions.sh" "$rel" || fail "release should refuse a tag whose plugin versions do not match"
+
+tests="$ROOT/.github/workflows/tests.yml"
+grep -q "pull_request" "$tests" || fail "tests workflow should still run on pull_request"
+grep -q "push" "$tests" || fail "tests workflow should still run on push"
+grep -q "main" "$tests" || fail "tests workflow should still run on main"
+grep -q "tests/\*\.sh" "$tests" || fail "tests workflow should still run tests/*.sh"
+if grep -q "gh release create" "$tests"; then
+  fail "push to main must not create a Release"
+fi
+
+need_text() {
+  local file="$1" pat="$2"
+  grep -q -- "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+}
+
+need_text README.md "git clone"
+need_text README.md "./install.sh"
+need_text README.md "from-source"
+need_text README.md "git tag"
+need_text README.md "v1.0.0"
+need_text README.md "Releases"
+
+echo "ok release"

--- a/tests/release.sh
+++ b/tests/release.sh
@@ -10,34 +10,49 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 check="$ROOT/scripts/check-plugin-versions.sh"
 [[ -x "$check" ]] || fail "missing executable scripts/check-plugin-versions.sh"
 
-"$check" v1.0.0 || fail "v1.0.0 should match plugin versions in this checkout"
+write_plugin() {
+  local dest="$1" version="$2" extra="${3:-}"
+  mkdir -p "$(dirname "$dest")"
+  if [[ -n "$extra" ]]; then
+    printf '{"name":"fixture","description":"%s","version":"%s"}\n' "$extra" "$version" >"$dest"
+  else
+    printf '{"name":"fixture","version":"%s"}\n' "$version" >"$dest"
+  fi
+}
+
+pack_plugins() {
+  local dest="$1" version="$2"
+  mkdir -p "$dest/.claude-plugin" "$dest/.cursor-plugin" "$dest/.grok-plugin"
+  write_plugin "$dest/.claude-plugin/plugin.json" "$version"
+  write_plugin "$dest/.cursor-plugin/plugin.json" "$version"
+  write_plugin "$dest/.grok-plugin/plugin.json" "$version"
+}
 
 fx="$TMP/pack"
-mkdir -p "$fx/.claude-plugin" "$fx/.cursor-plugin" "$fx/.grok-plugin"
-for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json .grok-plugin/plugin.json; do
-  cp "$ROOT/$f" "$fx/$f"
-done
-"$check" v1.0.0 "$fx" || fail "fixture at 1.0.0 should pass v1.0.0"
+pack_plugins "$fx" "3.2.1"
+"$check" v3.2.1 "$fx" || fail "compact fixture at 3.2.1 should pass v3.2.1"
+
+write_plugin "$fx/.claude-plugin/plugin.json" "3.2.1" "mentions version in another key"
+"$check" v3.2.1 "$fx" || fail "version key should win when another field mentions version"
 
 set +e
-"$check" v2.0.0 "$fx" >"$TMP/out" 2>"$TMP/err"
+"$check" v9.9.9 "$fx" >"$TMP/out" 2>"$TMP/err"
 code=$?
 set -e
-[[ $code -ne 0 ]] || fail "v2.0.0 should fail when plugins are 1.0.0"
-grep -q "1.0.0" "$TMP/err" || fail "mismatch should name the plugin version: $(cat "$TMP/err")"
+[[ $code -ne 0 ]] || fail "v9.9.9 should fail when plugins are 3.2.1"
+grep -q "3.2.1" "$TMP/err" || fail "mismatch should name the plugin version: $(cat "$TMP/err")"
 
-sed 's/"1.0.0"/"1.0.1"/' "$fx/.cursor-plugin/plugin.json" >"$TMP/cursor.json"
-mv "$TMP/cursor.json" "$fx/.cursor-plugin/plugin.json"
+write_plugin "$fx/.cursor-plugin/plugin.json" "3.2.2"
 set +e
-"$check" v1.0.0 "$fx" >"$TMP/out" 2>"$TMP/err"
+"$check" v3.2.1 "$fx" >"$TMP/out" 2>"$TMP/err"
 code=$?
 set -e
 [[ $code -ne 0 ]] || fail "one plugin off the tag should fail"
-cp "$ROOT/.cursor-plugin/plugin.json" "$fx/.cursor-plugin/plugin.json"
+write_plugin "$fx/.cursor-plugin/plugin.json" "3.2.1"
 
 rm "$fx/.grok-plugin/plugin.json"
 set +e
-"$check" v1.0.0 "$fx" >"$TMP/out" 2>"$TMP/err"
+"$check" v3.2.1 "$fx" >"$TMP/out" 2>"$TMP/err"
 code=$?
 set -e
 [[ $code -ne 0 ]] || fail "missing plugin.json should fail"


### PR DESCRIPTION
A person who pushes a vX.Y.Z tag gets a GitHub Release after plugin versions in that commit match the tag. Clone plus ./install.sh is still the from-source install. Merge to main does not publish a Release. Ticket #28.