### PR TITLE
Feat/29/install from GitHub marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -17,8 +17,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity",
-      "version": "1.0.0"
+      "category": "Productivity"
     }
   ]
 }

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "software-factory",
+  "owner": {
+    "name": "Kripu Khadka"
+  },
+  "interface": {
+    "displayName": "Software factory"
+  },
+  "plugins": [
+    {
+      "name": "software-factory",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "software-factory",
+  "owner": {
+    "name": "Kripu Khadka"
+  },
+  "description": "Lanes, tickets, and a human merge.",
+  "plugins": [
+    {
+      "name": "software-factory",
+      "source": "./",
+      "description": "Lanes, tickets, and a human merge. Same skills as Cursor, Grok, and Codex.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Kripu Khadka"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,6 @@
       "name": "software-factory",
       "source": "./",
       "description": "Lanes, tickets, and a human merge. Same skills as Cursor, Grok, and Codex.",
-      "version": "1.0.0",
       "author": {
         "name": "Kripu Khadka"
       }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "software-factory",
+  "version": "1.0.0",
+  "description": "Lanes, tickets, and a human merge. Skills for Codex.",
+  "author": {
+    "name": "Kripu Khadka"
+  },
+  "homepage": "https://github.com/Kripu77/software-factory",
+  "repository": "https://github.com/Kripu77/software-factory",
+  "license": "MIT",
+  "keywords": ["software-factory", "tdd", "review", "telemetry"],
+  "skills": "./skills/"
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -10,8 +10,7 @@
     {
       "name": "software-factory",
       "source": "./",
-      "description": "Lanes, tickets, and a human merge. Skills and commands for Cursor, Claude, Grok, and Codex.",
-      "version": "1.0.0"
+      "description": "Lanes, tickets, and a human merge. Skills and commands for Cursor, Claude, Grok, and Codex."
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "software-factory",
+  "owner": {
+    "name": "Kripu Khadka"
+  },
+  "metadata": {
+    "description": "Lanes, tickets, and a human merge."
+  },
+  "plugins": [
+    {
+      "name": "software-factory",
+      "source": "./",
+      "description": "Lanes, tickets, and a human merge. Skills and commands for Cursor, Claude, Grok, and Codex.",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,8 +9,10 @@
       "name": "software-factory",
       "description": "Lanes, tickets, and a human merge. Skills and slash commands for Grok Build.",
       "category": "development",
-      "version": "1.0.0",
-      "source": "./",
+      "source": {
+        "type": "local",
+        "path": "./"
+      },
       "homepage": "https://github.com/Kripu77/software-factory"
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "software-factory",
+  "description": "Lanes, tickets, and a human merge.",
+  "owner": {
+    "name": "Kripu Khadka"
+  },
+  "plugins": [
+    {
+      "name": "software-factory",
+      "description": "Lanes, tickets, and a human merge. Skills and slash commands for Grok Build.",
+      "category": "development",
+      "version": "1.0.0",
+      "source": "./",
+      "homepage": "https://github.com/Kripu77/software-factory"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Codex:
 
 ```
 codex plugin marketplace add Kripu77/software-factory@v1.0.0
-codex plugin install software-factory@software-factory
+codex plugin add software-factory@software-factory
 ```
 
 Cursor:

--- a/README.md
+++ b/README.md
@@ -48,13 +48,45 @@ Floor asks GitHub whether there is a PR, a review, and green checks. It asks loc
 
 ## Install
 
+Add this GitHub repo as a marketplace and install software-factory at the Release tag. Not main.
+
+Claude Code:
+
+```
+/plugin marketplace add Kripu77/software-factory@v1.0.0
+/plugin install software-factory@software-factory
+```
+
+Grok Build:
+
+```
+grok plugin install Kripu77/software-factory@v1.0.0 --trust
+```
+
+Or add this repo as a marketplace at tag `v1.0.0`, then install software-factory.
+
+Codex:
+
+```
+codex plugin marketplace add Kripu77/software-factory@v1.0.0
+codex plugin install software-factory@software-factory
+```
+
+Cursor:
+
+Add GitHub marketplace `Kripu77/software-factory` at tag `v1.0.0`, then install software-factory.
+
+`/lead` loads. So do the other factory commands. Codex gets the skills.
+
+Clone plus `./install.sh` is the from-source path:
+
 ```bash
 git clone https://github.com/Kripu77/software-factory.git
 cd software-factory
 ./install.sh
 ```
 
-Clone plus `./install.sh` is the from-source path. That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/.local/bin`. Codex: `./install.sh /path/to/your-checkout` also writes `AGENTS.md` there. Then:
+That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/.local/bin`. Codex: `./install.sh /path/to/your-checkout` also writes `AGENTS.md` there. Then:
 
 ```bash
 cd /path/to/your-checkout
@@ -62,7 +94,7 @@ grok          # or claude
 /lead
 ```
 
-The versioned pack is on GitHub Releases. Set plugin versions in `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and `.grok-plugin/plugin.json` to the tag without the `v`, then:
+The versioned pack is on GitHub Releases. Set plugin versions in `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.grok-plugin/plugin.json`, and `.codex-plugin/plugin.json` to the tag without the `v`, then:
 
 ```bash
 git tag v1.0.0
@@ -75,10 +107,10 @@ Owner and repo come from `git remote`. Workspace is this directory. Put `~/.loca
 
 | Harness | How it loads |
 | --- | --- |
-| Cursor | local plugin at `~/.cursor/plugins/local/software-factory` |
-| Claude Code | skills + slash commands under `~/.claude` |
-| Grok Build | plugin at `~/.grok/plugins/software-factory` (`grok plugin install . --trust`) |
-| Codex | skills under `~/.codex/skills` plus `AGENTS.md` in the product checkout |
+| Cursor | GitHub marketplace at the Release tag, or local plugin at `~/.cursor/plugins/local/software-factory` |
+| Claude Code | marketplace plugin at the Release tag, or skills + slash commands under `~/.claude` |
+| Grok Build | GitHub shorthand at the Release tag, or `grok plugin install . --trust` from a clone |
+| Codex | marketplace plugin at the Release tag, or skills under `~/.codex/skills` plus `AGENTS.md` |
 
 ## Run
 

--- a/scripts/check-plugin-versions.sh
+++ b/scripts/check-plugin-versions.sh
@@ -10,7 +10,7 @@ plugin_version() {
   python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$1"
 }
 
-for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json .grok-plugin/plugin.json; do
+for f in .claude-plugin/plugin.json .cursor-plugin/plugin.json .grok-plugin/plugin.json .codex-plugin/plugin.json; do
   path="$root/$f"
   [[ -f "$path" ]] || { echo "missing $f" >&2; exit 1; }
   got="$(plugin_version "$path")"

--- a/tests/marketplace.sh
+++ b/tests/marketplace.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+need_text() {
+  local file="$1" pat="$2"
+  grep -q -- "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+}
+
+need_file() {
+  local file="$1"
+  [[ -f "$ROOT/$file" ]] || fail "missing $file"
+}
+
+plugin_version() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$1"
+}
+
+assert_marketplace() {
+  local file="$1"
+  need_file "$file"
+  python3 - "$ROOT/$file" <<'PY' || fail "$file is not a valid software-factory marketplace"
+import json, sys
+
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+
+if not isinstance(data, dict):
+    raise SystemExit(f"{path} must be a JSON object")
+if data.get("name") != "software-factory":
+    raise SystemExit(f"{path} name must be software-factory")
+owner = data.get("owner") or {}
+if not owner.get("name"):
+    raise SystemExit(f"{path} needs owner.name")
+plugins = data.get("plugins")
+if not isinstance(plugins, list) or not plugins:
+    raise SystemExit(f"{path} needs a plugins list")
+
+def is_local_root(source):
+    if source in ("./", "."):
+        return True
+    if isinstance(source, dict):
+        path_val = source.get("path")
+        if path_val in ("./", "."):
+            return True
+        if source.get("type") == "local" and path_val in ("./", ".", None):
+            return True
+    return False
+
+found = None
+for plugin in plugins:
+    if plugin.get("name") == "software-factory":
+        found = plugin
+        break
+if found is None:
+    raise SystemExit(f"{path} must list plugin software-factory")
+if not is_local_root(found.get("source")):
+    raise SystemExit(f"{path} software-factory source must be this repo, not a remote main")
+version = found.get("version")
+if version is not None and not version:
+    raise SystemExit(f"{path} plugin version is empty")
+PY
+}
+
+want="$(plugin_version "$ROOT/.claude-plugin/plugin.json")"
+
+assert_marketplace ".claude-plugin/marketplace.json"
+assert_marketplace ".grok-plugin/marketplace.json"
+assert_marketplace ".cursor-plugin/marketplace.json"
+assert_marketplace ".agents/plugins/marketplace.json"
+
+need_file ".codex-plugin/plugin.json"
+codex_ver="$(plugin_version "$ROOT/.codex-plugin/plugin.json")"
+[[ "$codex_ver" == "$want" ]] || fail ".codex-plugin/plugin.json version $codex_ver does not match .claude-plugin/plugin.json $want"
+grep -q '"name": "software-factory"' "$ROOT/.codex-plugin/plugin.json" || fail ".codex-plugin/plugin.json name must be software-factory"
+grep -q 'skills' "$ROOT/.codex-plugin/plugin.json" || fail ".codex-plugin/plugin.json must point at skills"
+
+check="$ROOT/scripts/check-plugin-versions.sh"
+"$check" "v${want}" "$ROOT" || fail "plugin versions should match v${want}"
+grep -q '.codex-plugin/plugin.json' "$check" || fail "check-plugin-versions.sh should check .codex-plugin/plugin.json"
+
+need_file "commands/lead.md"
+grep -q '^name: lead$' "$ROOT/commands/lead.md" || fail "commands/lead.md should declare /lead"
+
+readme="$ROOT/README.md"
+need_text README.md "/plugin marketplace add Kripu77/software-factory@v${want}"
+need_text README.md "/plugin install software-factory@software-factory"
+need_text README.md "grok plugin install Kripu77/software-factory@v${want}"
+need_text README.md "codex plugin marketplace add Kripu77/software-factory@v${want}"
+need_text README.md "git clone"
+need_text README.md "./install.sh"
+need_text README.md "from-source"
+
+python3 - "$readme" "$want" <<'PY' || fail "README Install must lead with tagged marketplace install, not clone from main"
+import sys, re
+path, version = sys.argv[1], sys.argv[2]
+text = open(path).read()
+start = text.find("\n## Install\n")
+if start < 0:
+    raise SystemExit("README missing ## Install")
+rest = text[start + 1:]
+nxt = rest.find("\n## ")
+section = rest if nxt < 0 else rest[:nxt]
+if re.search(r"software-factory@(main|master)\b", section) or re.search(r"--ref main\b", section):
+    raise SystemExit("Install section must not use unversioned main")
+tag = f"Kripu77/software-factory@v{version}"
+if tag not in section:
+    raise SystemExit(f"Install section must pin {tag}")
+market = section.find(tag)
+clone = section.find("git clone")
+if market < 0:
+    raise SystemExit("Install section must name the tagged GitHub repo")
+if clone < 0:
+    raise SystemExit("Install section must keep git clone as from-source")
+if market > clone:
+    raise SystemExit("marketplace one-liners must lead; clone plus ./install.sh follows")
+for needle in ("Claude", "Grok", "Codex", "Cursor"):
+    if needle.lower() not in section.lower():
+        raise SystemExit(f"Install section must cover {needle}")
+PY
+
+echo "ok marketplace"

--- a/tests/marketplace.sh
+++ b/tests/marketplace.sh
@@ -19,16 +19,13 @@ plugin_version() {
   python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$1"
 }
 
-assert_marketplace() {
-  local file="$1"
-  need_file "$file"
-  python3 - "$ROOT/$file" <<'PY' || fail "$file is not a valid software-factory marketplace"
+assert_claude_marketplace() {
+  need_file ".claude-plugin/marketplace.json"
+  python3 - "$ROOT/.claude-plugin/marketplace.json" <<'PY' || fail ".claude-plugin/marketplace.json is not a Claude marketplace"
 import json, sys
 
 path = sys.argv[1]
-with open(path) as f:
-    data = json.load(f)
-
+data = json.load(open(path))
 if not isinstance(data, dict):
     raise SystemExit(f"{path} must be a JSON object")
 if data.get("name") != "software-factory":
@@ -39,39 +36,110 @@ if not owner.get("name"):
 plugins = data.get("plugins")
 if not isinstance(plugins, list) or not plugins:
     raise SystemExit(f"{path} needs a plugins list")
-
-def is_local_root(source):
-    if source in ("./", "."):
-        return True
-    if isinstance(source, dict):
-        path_val = source.get("path")
-        if path_val in ("./", "."):
-            return True
-        if source.get("type") == "local" and path_val in ("./", ".", None):
-            return True
-    return False
-
-found = None
-for plugin in plugins:
-    if plugin.get("name") == "software-factory":
-        found = plugin
-        break
+found = next((p for p in plugins if p.get("name") == "software-factory"), None)
 if found is None:
     raise SystemExit(f"{path} must list plugin software-factory")
-if not is_local_root(found.get("source")):
-    raise SystemExit(f"{path} software-factory source must be this repo, not a remote main")
-version = found.get("version")
-if version is not None and not version:
-    raise SystemExit(f"{path} plugin version is empty")
+if found.get("source") != "./":
+    raise SystemExit(f"{path} software-factory source must be the relative path ./")
+if "version" in found:
+    raise SystemExit(f"{path} must not set plugin version; .claude-plugin/plugin.json is canonical")
+PY
+}
+
+assert_grok_marketplace() {
+  need_file ".grok-plugin/marketplace.json"
+  python3 - "$ROOT/.grok-plugin/marketplace.json" <<'PY' || fail ".grok-plugin/marketplace.json is not a Grok marketplace"
+import json, sys
+
+path = sys.argv[1]
+data = json.load(open(path))
+if not isinstance(data, dict):
+    raise SystemExit(f"{path} must be a JSON object")
+if data.get("name") != "software-factory":
+    raise SystemExit(f"{path} name must be software-factory")
+owner = data.get("owner") or {}
+if not owner.get("name"):
+    raise SystemExit(f"{path} needs owner.name")
+plugins = data.get("plugins")
+if not isinstance(plugins, list) or not plugins:
+    raise SystemExit(f"{path} needs a plugins list")
+found = next((p for p in plugins if p.get("name") == "software-factory"), None)
+if found is None:
+    raise SystemExit(f"{path} must list plugin software-factory")
+source = found.get("source")
+if not (isinstance(source, dict) and source.get("type") == "local" and source.get("path") == "./"):
+    raise SystemExit(f"{path} software-factory source must be {{type: local, path: ./}}")
+if "version" in found:
+    raise SystemExit(f"{path} must not set plugin version; .grok-plugin/plugin.json is canonical")
+PY
+}
+
+assert_cursor_marketplace() {
+  need_file ".cursor-plugin/marketplace.json"
+  python3 - "$ROOT/.cursor-plugin/marketplace.json" <<'PY' || fail ".cursor-plugin/marketplace.json is not a Cursor marketplace"
+import json, sys
+
+path = sys.argv[1]
+data = json.load(open(path))
+if not isinstance(data, dict):
+    raise SystemExit(f"{path} must be a JSON object")
+if data.get("name") != "software-factory":
+    raise SystemExit(f"{path} name must be software-factory")
+owner = data.get("owner") or {}
+if not owner.get("name"):
+    raise SystemExit(f"{path} needs owner.name")
+plugins = data.get("plugins")
+if not isinstance(plugins, list) or not plugins:
+    raise SystemExit(f"{path} needs a plugins list")
+found = next((p for p in plugins if p.get("name") == "software-factory"), None)
+if found is None:
+    raise SystemExit(f"{path} must list plugin software-factory")
+allowed = {"name", "source", "description", "minClientVersions"}
+extra = set(found) - allowed
+if extra:
+    raise SystemExit(f"{path} plugin entries may only have {sorted(allowed)}; extra {sorted(extra)}")
+if found.get("source") != "./":
+    raise SystemExit(f"{path} software-factory source must be ./")
+PY
+}
+
+assert_codex_marketplace() {
+  need_file ".agents/plugins/marketplace.json"
+  python3 - "$ROOT/.agents/plugins/marketplace.json" <<'PY' || fail ".agents/plugins/marketplace.json is not a Codex marketplace"
+import json, sys
+
+path = sys.argv[1]
+data = json.load(open(path))
+if not isinstance(data, dict):
+    raise SystemExit(f"{path} must be a JSON object")
+if data.get("name") != "software-factory":
+    raise SystemExit(f"{path} name must be software-factory")
+owner = data.get("owner") or {}
+if not owner.get("name"):
+    raise SystemExit(f"{path} needs owner.name")
+plugins = data.get("plugins")
+if not isinstance(plugins, list) or not plugins:
+    raise SystemExit(f"{path} needs a plugins list")
+found = next((p for p in plugins if p.get("name") == "software-factory"), None)
+if found is None:
+    raise SystemExit(f"{path} must list plugin software-factory")
+source = found.get("source")
+if not (isinstance(source, dict) and source.get("source") == "local" and source.get("path") == "./"):
+    raise SystemExit(f"{path} software-factory source must be {{source: local, path: ./}}")
+if "version" in found:
+    raise SystemExit(f"{path} must not set plugin version; .codex-plugin/plugin.json is canonical")
+policy = found.get("policy") or {}
+if not policy.get("installation") or not policy.get("authentication"):
+    raise SystemExit(f"{path} software-factory needs policy.installation and policy.authentication")
 PY
 }
 
 want="$(plugin_version "$ROOT/.claude-plugin/plugin.json")"
 
-assert_marketplace ".claude-plugin/marketplace.json"
-assert_marketplace ".grok-plugin/marketplace.json"
-assert_marketplace ".cursor-plugin/marketplace.json"
-assert_marketplace ".agents/plugins/marketplace.json"
+assert_claude_marketplace
+assert_grok_marketplace
+assert_cursor_marketplace
+assert_codex_marketplace
 
 need_file ".codex-plugin/plugin.json"
 codex_ver="$(plugin_version "$ROOT/.codex-plugin/plugin.json")"
@@ -82,6 +150,9 @@ grep -q 'skills' "$ROOT/.codex-plugin/plugin.json" || fail ".codex-plugin/plugin
 check="$ROOT/scripts/check-plugin-versions.sh"
 "$check" "v${want}" "$ROOT" || fail "plugin versions should match v${want}"
 grep -q '.codex-plugin/plugin.json' "$check" || fail "check-plugin-versions.sh should check .codex-plugin/plugin.json"
+if grep -q 'marketplace.json' "$check"; then
+  fail "check-plugin-versions.sh should gate plugin.json only, not marketplace catalogs"
+fi
 
 need_file "commands/lead.md"
 grep -q '^name: lead$' "$ROOT/commands/lead.md" || fail "commands/lead.md should declare /lead"
@@ -91,6 +162,10 @@ need_text README.md "/plugin marketplace add Kripu77/software-factory@v${want}"
 need_text README.md "/plugin install software-factory@software-factory"
 need_text README.md "grok plugin install Kripu77/software-factory@v${want}"
 need_text README.md "codex plugin marketplace add Kripu77/software-factory@v${want}"
+need_text README.md "codex plugin add software-factory@software-factory"
+if grep -q "codex plugin install" "$readme"; then
+  fail "Codex install command is plugin add, not plugin install"
+fi
 need_text README.md "git clone"
 need_text README.md "./install.sh"
 need_text README.md "from-source"

--- a/tests/release.sh
+++ b/tests/release.sh
@@ -22,10 +22,11 @@ write_plugin() {
 
 pack_plugins() {
   local dest="$1" version="$2"
-  mkdir -p "$dest/.claude-plugin" "$dest/.cursor-plugin" "$dest/.grok-plugin"
+  mkdir -p "$dest/.claude-plugin" "$dest/.cursor-plugin" "$dest/.grok-plugin" "$dest/.codex-plugin"
   write_plugin "$dest/.claude-plugin/plugin.json" "$version"
   write_plugin "$dest/.cursor-plugin/plugin.json" "$version"
   write_plugin "$dest/.grok-plugin/plugin.json" "$version"
+  write_plugin "$dest/.codex-plugin/plugin.json" "$version"
 }
 
 fx="$TMP/pack"


### PR DESCRIPTION
Implements #29. A stranger can add this GitHub repo as a marketplace, or install from GitHub shorthand at the Release tag, in Claude Code, Grok Build, Cursor, and Codex, then get /lead and the factory skills. Clone plus ./install.sh stays the from-source path. README leads with those one-liners.

Do not merge until review and CI are green.