### PR TITLE
Feat/35/per-repo conventions in lane rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Headless. Never merges.
 
 `factory.sh ship` is an alias of `floor`. QA URL is `--url` or `FACTORY_QA_URL`. `--yes` is for workers. Lead stays interactive for quiz and for `blocked`.
 
+Per-repo conventions: drop `.factory/conventions` in the target checkout, one skill name per line (any skill available to the runner, e.g. `euc-go`). Feature, bug, and docs lanes are told to invoke each listed skill before writing code. The file stays out of source control: factory.sh adds `.factory/` to the checkout's `.git/info/exclude` when it reads it.
+
 ## What this pack will not do
 
 A person still quizzes before tickets, logs in for a protected browser, and merges.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Headless. Never merges.
 
 `factory.sh ship` is an alias of `floor`. QA URL is `--url` or `FACTORY_QA_URL`. `--yes` is for workers. Lead stays interactive for quiz and for `blocked`.
 
-Per-repo conventions: drop `.factory/conventions` in the target checkout, one skill name per line (any skill available to the runner, e.g. `euc-go`). Feature, bug, and docs lanes are told to invoke each listed skill before writing code. The file stays out of source control: factory.sh adds `.factory/` to the checkout's `.git/info/exclude` when it reads it.
+Per-repo conventions: feature, bug, and docs lanes are always told to check for relevant skills before writing code. To steer them, author `.factory/conventions` in the target checkout. Each line is one of: `# comment`, `skill-name: when it applies` (a skill entry with context, e.g. `euc-go: Go services and migrations`), a bare `skill-name`, or any other text, injected verbatim as repo context (e.g. `never add jest tests; never raw HTML`). Any skill available to the runner can be listed; the lane is told to invoke each one that applies. factory.sh adds `.factory/` to the checkout's `.git/info/exclude` when it reads the file, which keeps an untracked file from being committed.
 
 ## What this pack will not do
 

--- a/factory.sh
+++ b/factory.sh
@@ -169,19 +169,29 @@ repo_dir() {
 }
 
 conventions_rules() {
-  local dir="$1" file="$1/.factory/conventions" line skills=""
-  [[ -f "$file" ]] || return 0
-  if [[ -d "$dir/.git" ]] && ! grep -qxF '.factory/' "$dir/.git/info/exclude" 2>/dev/null; then
-    mkdir -p "$dir/.git/info"
-    printf '.factory/\n' >> "$dir/.git/info/exclude"
+  local dir="$1" file="$1/.factory/conventions" line skills="" context=""
+  if [[ -f "$file" ]]; then
+    if [[ -d "$dir/.git" ]] && ! grep -qxF '.factory/' "$dir/.git/info/exclude" 2>/dev/null; then
+      mkdir -p "$dir/.git/info"
+      printf '.factory/\n' >> "$dir/.git/info/exclude"
+    fi
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      [[ -n "$line" && "$line" != \#* ]] || continue
+      if [[ "$line" =~ ^([^[:space:]]+):[[:space:]]+(.+)$ ]]; then
+        skills+=$'\n'"- /${BASH_REMATCH[1]}: ${BASH_REMATCH[2]}"
+      elif [[ "$line" != *[[:space:]]* ]]; then
+        skills+=$'\n'"- /$line"
+      else
+        context+=$'\n'"- $line"
+      fi
+    done < "$file"
   fi
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    line="${line//[[:space:]]/}"
-    [[ -n "$line" ]] || continue
-    skills="${skills:+$skills, }/$line"
-  done < "$file"
-  [[ -n "$skills" ]] || return 0
-  printf 'This repo has conventions. Before writing code invoke each of these skills and follow its conventions: %s.\n' "$skills"
+  local out='Check for relevant skills before writing code and follow their conventions.'
+  [[ -z "$skills" ]] || out+=$'\n'"This repo enables these skills; invoke each one that applies before writing code:$skills"
+  [[ -z "$context" ]] || out+=$'\n'"Repo context:$context"
+  printf '%s\n' "$out"
 }
 
 run_agent() {

--- a/factory.sh
+++ b/factory.sh
@@ -168,6 +168,22 @@ repo_dir() {
   fi
 }
 
+conventions_rules() {
+  local dir="$1" file="$1/.factory/conventions" line skills=""
+  [[ -f "$file" ]] || return 0
+  if [[ -d "$dir/.git" ]] && ! grep -qxF '.factory/' "$dir/.git/info/exclude" 2>/dev/null; then
+    mkdir -p "$dir/.git/info"
+    printf '.factory/\n' >> "$dir/.git/info/exclude"
+  fi
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line//[[:space:]]/}"
+    [[ -n "$line" ]] || continue
+    skills="${skills:+$skills, }/$line"
+  done < "$file"
+  [[ -n "$skills" ]] || return 0
+  printf 'This repo has conventions. Before writing code invoke each of these skills and follow its conventions: %s.\n' "$skills"
+}
+
 run_agent() {
   local cwd="$1"
   local rules="$2"
@@ -935,7 +951,10 @@ case "$LANE" in
   feature|bug|docs)
     need_issue
     DIR="$(repo_dir)"
-    run_mem_lane "$LANE" "$DIR" "$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD" "Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
+    RULES="$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD"
+    CONVENTIONS="$(conventions_rules "$DIR")"
+    [[ -z "$CONVENTIONS" ]] || RULES+=$'\n'"$CONVENTIONS"
+    run_mem_lane "$LANE" "$DIR" "$RULES" "Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
     exit $?
     ;;
   review)

--- a/tests/conventions.sh
+++ b/tests/conventions.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+unset FACTORY_SKIP_TICKET_COMMENT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
+DUMP="$TMP/dump"
+mkdir -p "$DUMP" "$TMP/bin"
+
+cat > "$TMP/bin/runner" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p) printf '%s\n' "$2" > "$dump/prompt"; shift 2 ;;
+    --rules) printf '%s\n' "$2" > "$dump/rules"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+exit 0
+EOF
+chmod +x "$TMP/bin/runner"
+
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+
+run_lane() {
+  local lane="$1"
+  PATH="$TMP/bin:$PATH" \
+    FAKE_DUMP="$DUMP" \
+    FACTORY_WORKSPACE="$WS" \
+    FACTORY_OWNER=acme \
+    FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
+    "$FACTORY" "$lane" --repo widgets --issue 6 >/dev/null 2>&1
+}
+
+# Missing conventions file: lane runs, rules untouched
+run_lane feature
+[[ -f "$DUMP/rules" ]] || fail "feature should run without conventions file"
+grep -q "conventions" "$DUMP/rules" && fail "no conventions file must not inject conventions rule"
+
+# Conventions file: each lane gets a must-invoke instruction with every listed skill
+mkdir -p "$WS/widgets/.factory"
+printf 'euc-go\neuc-react-native\n' > "$WS/widgets/.factory/conventions"
+for lane in feature bug docs; do
+  rm -rf "$DUMP"
+  mkdir -p "$DUMP"
+  run_lane "$lane"
+  grep -q "euc-go" "$DUMP/rules" || fail "$lane rules missing euc-go"
+  grep -q "euc-react-native" "$DUMP/rules" || fail "$lane rules missing euc-react-native"
+  grep -qi "invoke" "$DUMP/rules" || fail "$lane rules missing invoke instruction"
+done
+
+# Reading the file excludes .factory/ from source control
+grep -qxF ".factory/" "$WS/widgets/.git/info/exclude" || fail ".factory/ missing from .git/info/exclude"
+run_lane feature
+[[ "$(grep -cxF '.factory/' "$WS/widgets/.git/info/exclude")" == "1" ]] || fail ".factory/ excluded more than once"
+
+# Blank lines are skipped
+printf '\neuc-sql\n\n' > "$WS/widgets/.factory/conventions"
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+run_lane feature
+grep -q "euc-sql" "$DUMP/rules" || fail "rules missing euc-sql"
+
+# Empty file behaves like a missing file
+: > "$WS/widgets/.factory/conventions"
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+run_lane feature
+grep -q "conventions" "$DUMP/rules" && fail "empty conventions file must not inject conventions rule"
+
+# README documents the file
+grep -q ".factory/conventions" "$ROOT/README.md" || fail "README missing .factory/conventions"
+grep -qi "one skill" "$ROOT/README.md" || fail "README missing one-skill-per-line format"
+
+echo "ok conventions"

--- a/tests/conventions.sh
+++ b/tests/conventions.sh
@@ -49,21 +49,29 @@ run_lane() {
     "$FACTORY" "$lane" --repo widgets --issue 6 >/dev/null 2>&1
 }
 
-# Missing conventions file: lane runs, rules untouched
+# Missing conventions file: the generic skill-check instruction is still injected
 run_lane feature
 [[ -f "$DUMP/rules" ]] || fail "feature should run without conventions file"
-grep -q "conventions" "$DUMP/rules" && fail "no conventions file must not inject conventions rule"
+grep -q "Check for relevant skills before writing code" "$DUMP/rules" || fail "missing file must still inject the generic skill-check instruction"
+grep -q "This repo enables these skills" "$DUMP/rules" && fail "missing file must not inject a skill list"
 
-# Conventions file: each lane gets a must-invoke instruction with every listed skill
+# Conventions file: skill entries with context and repo context reach every implementing lane
 mkdir -p "$WS/widgets/.factory"
-printf 'euc-go\neuc-react-native\n' > "$WS/widgets/.factory/conventions"
+cat > "$WS/widgets/.factory/conventions" << 'CONV'
+# tooling notes
+go-style: services and migrations
+web-style: web frontends
+never add jest tests; never raw HTML
+CONV
 for lane in feature bug docs; do
   rm -rf "$DUMP"
   mkdir -p "$DUMP"
   run_lane "$lane"
-  grep -q "euc-go" "$DUMP/rules" || fail "$lane rules missing euc-go"
-  grep -q "euc-react-native" "$DUMP/rules" || fail "$lane rules missing euc-react-native"
+  grep -q "/go-style: services and migrations" "$DUMP/rules" || fail "$lane rules missing go-style with its context"
+  grep -q "/web-style: web frontends" "$DUMP/rules" || fail "$lane rules missing web-style with its context"
+  grep -q "never add jest tests; never raw HTML" "$DUMP/rules" || fail "$lane rules missing repo context line"
   grep -qi "invoke" "$DUMP/rules" || fail "$lane rules missing invoke instruction"
+  grep -q "tooling notes" "$DUMP/rules" && fail "$lane rules must not include comment lines"
 done
 
 # Reading the file excludes .factory/ from source control
@@ -71,22 +79,23 @@ grep -qxF ".factory/" "$WS/widgets/.git/info/exclude" || fail ".factory/ missing
 run_lane feature
 [[ "$(grep -cxF '.factory/' "$WS/widgets/.git/info/exclude")" == "1" ]] || fail ".factory/ excluded more than once"
 
-# Blank lines are skipped
-printf '\neuc-sql\n\n' > "$WS/widgets/.factory/conventions"
+# Blank lines are skipped and a bare skill name needs no context
+printf '\nsql-style\n\n' > "$WS/widgets/.factory/conventions"
 rm -rf "$DUMP"
 mkdir -p "$DUMP"
 run_lane feature
-grep -q "euc-sql" "$DUMP/rules" || fail "rules missing euc-sql"
+grep -q "/sql-style" "$DUMP/rules" || fail "rules missing bare skill sql-style"
 
 # Empty file behaves like a missing file
 : > "$WS/widgets/.factory/conventions"
 rm -rf "$DUMP"
 mkdir -p "$DUMP"
 run_lane feature
-grep -q "conventions" "$DUMP/rules" && fail "empty conventions file must not inject conventions rule"
+grep -q "Check for relevant skills before writing code" "$DUMP/rules" || fail "empty file must still inject the generic skill-check instruction"
+grep -q "This repo enables these skills" "$DUMP/rules" && fail "empty conventions file must not inject a skill list"
 
 # README documents the file
 grep -q ".factory/conventions" "$ROOT/README.md" || fail "README missing .factory/conventions"
-grep -qi "one skill" "$ROOT/README.md" || fail "README missing one-skill-per-line format"
+grep -qi "repo context" "$ROOT/README.md" || fail "README missing repo-context format"
 
 echo "ok conventions"


### PR DESCRIPTION
Feature, bug, and docs dispatches now read `.factory/conventions` from the target checkout (one skill name per line) and append a must-invoke instruction to the lane rules, adding `.factory/` to `.git/info/exclude` so the file never enters source control. Pattern ratified off PR #27 (close-linked): a factory.sh function plus its own tests/*.sh file, asserted through the fake-runner rules dump like tests/lanes.sh. For #35.