### PR TITLE
Bug/38/let the review lane invoke its mandated skill

### DIFF
--- a/skills/thermo-nuclear-review/SKILL.md
+++ b/skills/thermo-nuclear-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: thermo-nuclear-code-quality-review
-description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
-disable-model-invocation: true
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review. Only use when explicitly asked to review; never during implementation.
 ---
 
 # Thermo-Nuclear Code Quality Review

--- a/tests/lanes.sh
+++ b/tests/lanes.sh
@@ -59,6 +59,10 @@ playbook() {
   fi
 }
 
+if grep -q "disable-model-invocation: true" "$ROOT/skills/thermo-nuclear-review/SKILL.md"; then
+  fail "review lane mandates /thermo-nuclear-code-quality-review but the skill blocks model invocation"
+fi
+
 playbook feature feature
 playbook docs docs
 playbook qa qa


### PR DESCRIPTION
Every review dispatch tells the reviewer to run /thermo-nuclear-code-quality-review, but the skill set disable-model-invocation: true, so the harness refused it on every run. This drops the flag, moves the don't-use-during-implementation intent into the skill description, and adds a test that fails if the review lane's mandated skill is ever harness-blocked again.

Fixes #38