### PR TITLE
Feat/40/resolve addressed review threads

### DIFF
--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -24,6 +24,9 @@ gh api graphql -f query='query($owner:String!,$name:String!,$pr:Int!){repository
 
 # Resolve one addressed thread
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -F id=<thread-id>
+
+# Reply to a skipped or disputed thread (leave unresolved)
+gh api graphql -f query='mutation($id:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id,body:$body}){comment{url}}}' -F id=<thread-id> -f body='<why skipped or disputed>'
 ```
 
 ## Extra rules

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -14,6 +14,18 @@ Implement only the ticket you were given.
 5. Open or update a PR. Do not merge.
 6. Stop and ask for `/thermo-nuclear-code-quality-review` then `/loop-on-ci`.
 
+## Review feedback
+
+When you act on a review comment on your PR, resolve its thread. Threads you did not act on, or replied to with a dispute, stay unresolved with a reply.
+
+```bash
+# List threads with ids
+gh api graphql -f query='query($owner:String!,$name:String!,$pr:Int!){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100){nodes{id isResolved comments(first:1){nodes{path body}}}}}}}' -F owner=<owner> -F name=<repo> -F pr=<number>
+
+# Resolve one addressed thread
+gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -F id=<thread-id>
+```
+
 ## Extra rules
 
 - No code comments

--- a/tests/review-threads.sh
+++ b/tests/review-threads.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+need_text() {
+  local file="$1" pat="$2"
+  grep -q -- "$pat" "$ROOT/$file" || fail "$file missing /$pat/"
+}
+
+need_text skills/implement/SKILL.md "resolveReviewThread"
+need_text skills/implement/SKILL.md "reviewThreads"
+need_text skills/implement/SKILL.md "unresolved"
+need_text skills/implement/SKILL.md "reply"
+
+echo "ok review-threads"

--- a/tests/review-threads.sh
+++ b/tests/review-threads.sh
@@ -13,6 +13,6 @@ need_text() {
 need_text skills/implement/SKILL.md "resolveReviewThread"
 need_text skills/implement/SKILL.md "reviewThreads"
 need_text skills/implement/SKILL.md "unresolved"
-need_text skills/implement/SKILL.md "reply"
+need_text skills/implement/SKILL.md "addPullRequestReviewThreadReply"
 
 echo "ok review-threads"


### PR DESCRIPTION
Implementing lanes now resolve a PR review thread via gh GraphQL resolveReviewThread once they act on its comment; skipped or disputed threads get a reply and stay unresolved. Stated in the implement skill that the Feature and Bug lanes load, with a grep test. For #40.