### PR TITLE
Feat/43/factory.sh config for tracker and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,12 @@ Headless. Never merges.
 ./factory.sh qa --repo frontend --pr 12 --url http://localhost:3000
 ./factory.sh mem write --lane feature --status started --issue 12 --harness grok --summary "Add the memory store"
 ./factory.sh mem read --issue 12
+./factory.sh config tracker linear --team ABC
+./factory.sh config skills "euc-go: Go services" "euc-sql: migrations"
+./factory.sh config
 ```
+
+`factory.sh config` sets a checkout up for the factory without hand-editing files. `config tracker github|linear [--team <linear-team-key>]` stores the issue tracker in `.factory/config`; github is the default when no config exists, and linear requires a team key. `config skills "<skill-name>: <when it applies>" [more...]` replaces `.factory/conventions` with those entries, one per line. `config` with no arguments prints the current tracker and skills. It targets `--repo <name>` under the workspace, or the checkout you run it from. Both files live under `.factory/`, which factory.sh adds to the checkout's `.git/info/exclude` so they stay out of source control.
 
 `factory.sh ship` is an alias of `floor`. QA URL is `--url` or `FACTORY_QA_URL`. `--yes` is for workers. Lead stays interactive for quiz and for `blocked`.
 

--- a/factory.sh
+++ b/factory.sh
@@ -79,12 +79,13 @@ LIMIT=""
 
 CONFIG_CMD=""
 CONFIG_ARGS=()
+CONFIG_REPO_FLAG=""
 TEAM=""
 
 if [[ "$LANE" == "config" ]]; then
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --repo) REPO="${2:-}"; shift 2 ;;
+      --repo) REPO="${2:-}"; CONFIG_REPO_FLAG=1; shift 2 ;;
       --team) TEAM="${2:-}"; shift 2 ;;
       -h|--help) usage ;;
       --*) echo "Unknown arg: $1" >&2; usage ;;
@@ -195,8 +196,14 @@ repo_dir() {
 }
 
 config_dir() {
-  if [[ -n "$REPO" ]]; then
+  local top=""
+  if [[ -n "$CONFIG_REPO_FLAG" ]]; then
     repo_dir
+    return 0
+  fi
+  top="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$top" ]]; then
+    printf '%s\n' "$top"
   elif [[ -d "$WORKSPACE/.git" ]]; then
     printf '%s\n' "$WORKSPACE"
   else
@@ -206,11 +213,12 @@ config_dir() {
 }
 
 factory_exclude() {
-  local dir="$1"
+  local dir="$1" exclude="$1/.git/info/exclude"
   [[ -d "$dir/.git" ]] || return 0
-  grep -qxF '.factory/' "$dir/.git/info/exclude" 2>/dev/null && return 0
+  grep -qxF '.factory/' "$exclude" 2>/dev/null && return 0
   mkdir -p "$dir/.git/info"
-  printf '.factory/\n' >> "$dir/.git/info/exclude"
+  [[ ! -s "$exclude" || -z "$(tail -c1 "$exclude")" ]] || printf '\n' >> "$exclude"
+  printf '.factory/\n' >> "$exclude"
 }
 
 config_show() {
@@ -251,9 +259,12 @@ config_tracker() {
 }
 
 config_skills() {
-  local dir="$1"
+  local dir="$1" entry
   shift
   [[ $# -gt 0 ]] || { echo 'Need entries: factory.sh config skills "<skill-name>: <when it applies>" [more...]' >&2; exit 1; }
+  for entry in "$@"; do
+    [[ "$entry" == *": "* && "$entry" != *$'\n'* ]] || { echo "Skills entries are one line each: \"<skill-name>: <when it applies>\", got: $entry" >&2; exit 1; }
+  done
   mkdir -p "$dir/.factory"
   factory_exclude "$dir"
   printf '%s\n' "$@" > "$dir/.factory/conventions"

--- a/factory.sh
+++ b/factory.sh
@@ -201,11 +201,9 @@ config_dir() {
     repo_dir
     return 0
   fi
-  top="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  top="$(git rev-parse --show-toplevel 2>/dev/null || git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || true)"
   if [[ -n "$top" ]]; then
     printf '%s\n' "$top"
-  elif [[ -d "$WORKSPACE/.git" ]]; then
-    printf '%s\n' "$WORKSPACE"
   else
     echo "Need --repo <name> or a git checkout" >&2
     exit 1
@@ -213,10 +211,11 @@ config_dir() {
 }
 
 factory_exclude() {
-  local dir="$1" exclude="$1/.git/info/exclude"
-  [[ -d "$dir/.git" ]] || return 0
+  local dir="$1" exclude
+  exclude="$(git -C "$dir" rev-parse --git-path info/exclude 2>/dev/null)" || return 0
+  [[ "$exclude" == /* ]] || exclude="$dir/$exclude"
   grep -qxF '.factory/' "$exclude" 2>/dev/null && return 0
-  mkdir -p "$dir/.git/info"
+  mkdir -p "${exclude%/*}"
   [[ ! -s "$exclude" || -z "$(tail -c1 "$exclude")" ]] || printf '\n' >> "$exclude"
   printf '.factory/\n' >> "$exclude"
 }
@@ -1061,7 +1060,10 @@ case "$LANE" in
   config)
     DIR="$(config_dir)"
     case "$CONFIG_CMD" in
-      tracker) config_tracker "$DIR" "${CONFIG_ARGS[0]:-}" ;;
+      tracker)
+        [[ ${#CONFIG_ARGS[@]} -le 1 ]] || { echo "config tracker takes one value: factory.sh config tracker <github|linear>" >&2; exit 1; }
+        config_tracker "$DIR" "${CONFIG_ARGS[0]:-}"
+        ;;
       skills) config_skills "$DIR" ${CONFIG_ARGS[@]+"${CONFIG_ARGS[@]}"} ;;
       *) config_show "$DIR" ;;
     esac

--- a/factory.sh
+++ b/factory.sh
@@ -16,6 +16,9 @@ Usage:
   factory.sh telemetry        --question "<what broke>" [--yes]
   factory.sh qa               --repo <name> --pr <n> [--url <app>]
   factory.sh qa               --url <app>
+  factory.sh config           [--repo <name>]  prints the current tracker and skills
+  factory.sh config tracker   github|linear [--team <linear-team-key>] [--repo <name>]
+  factory.sh config skills    "<skill-name>: <when it applies>" [more...] [--repo <name>]
   factory.sh mem read         [--issue <n>] [--pr <n>] [--project owner/name] [--limit n]
   factory.sh mem write        --lane <lane> --status started|done|blocked|failed [--harness claude|codex|cursor|grok] [--issue <n>] [--pr <n>] [--project owner/name] [--summary s] [--next-steps s] [--evidence url-or-json]
   factory.sh close-linked     --pr <n> [--repo name] [--owner org]
@@ -74,7 +77,30 @@ NEXT_STEPS=""
 EVIDENCE=""
 LIMIT=""
 
-if [[ "$LANE" == "mem" ]]; then
+CONFIG_CMD=""
+CONFIG_ARGS=()
+TEAM=""
+
+if [[ "$LANE" == "config" ]]; then
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) REPO="${2:-}"; shift 2 ;;
+      --team) TEAM="${2:-}"; shift 2 ;;
+      -h|--help) usage ;;
+      --*) echo "Unknown arg: $1" >&2; usage ;;
+      *)
+        if [[ -n "$CONFIG_CMD" ]]; then
+          CONFIG_ARGS+=("$1")
+        elif [[ "$1" == "tracker" || "$1" == "skills" ]]; then
+          CONFIG_CMD="$1"
+        else
+          echo "Unknown config command: $1" >&2
+          usage
+        fi
+        shift ;;
+    esac
+  done
+elif [[ "$LANE" == "mem" ]]; then
   MEM_CMD="${1:-}"
   case "$MEM_CMD" in
     read|write) shift ;;
@@ -166,6 +192,72 @@ repo_dir() {
     echo "No git checkout for $REPO under $WORKSPACE" >&2
     exit 1
   fi
+}
+
+config_dir() {
+  if [[ -n "$REPO" ]]; then
+    repo_dir
+  elif [[ -d "$WORKSPACE/.git" ]]; then
+    printf '%s\n' "$WORKSPACE"
+  else
+    echo "Need --repo <name> or a git checkout" >&2
+    exit 1
+  fi
+}
+
+factory_exclude() {
+  local dir="$1"
+  [[ -d "$dir/.git" ]] || return 0
+  grep -qxF '.factory/' "$dir/.git/info/exclude" 2>/dev/null && return 0
+  mkdir -p "$dir/.git/info"
+  printf '.factory/\n' >> "$dir/.git/info/exclude"
+}
+
+config_show() {
+  local dir="$1" tracker="github" team="" line
+  if [[ -f "$dir/.factory/config" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      case "$line" in
+        tracker=*) tracker="${line#tracker=}" ;;
+        team=*) team="${line#team=}" ;;
+      esac
+    done < "$dir/.factory/config"
+  fi
+  printf 'tracker %s\n' "$tracker"
+  [[ -z "$team" ]] || printf 'team %s\n' "$team"
+  if [[ -s "$dir/.factory/conventions" ]]; then
+    printf 'skills:\n'
+    cat "$dir/.factory/conventions"
+  else
+    printf 'skills: none\n'
+  fi
+}
+
+config_tracker() {
+  local dir="$1" tracker="${2:-}"
+  case "$tracker" in
+    github) ;;
+    linear) [[ -n "$TEAM" ]] || { echo "Tracker linear needs --team <linear-team-key>" >&2; exit 1; } ;;
+    *) echo "Tracker must be github or linear" >&2; exit 1 ;;
+  esac
+  mkdir -p "$dir/.factory"
+  factory_exclude "$dir"
+  if [[ "$tracker" == linear ]]; then
+    printf 'tracker=linear\nteam=%s\n' "$TEAM" > "$dir/.factory/config"
+  else
+    printf 'tracker=github\n' > "$dir/.factory/config"
+  fi
+  config_show "$dir"
+}
+
+config_skills() {
+  local dir="$1"
+  shift
+  [[ $# -gt 0 ]] || { echo 'Need entries: factory.sh config skills "<skill-name>: <when it applies>" [more...]' >&2; exit 1; }
+  mkdir -p "$dir/.factory"
+  factory_exclude "$dir"
+  printf '%s\n' "$@" > "$dir/.factory/conventions"
+  config_show "$dir"
 }
 
 run_agent() {
@@ -931,6 +1023,14 @@ case "$LANE" in
     ;;
   close-linked)
     close_linked_issues
+    ;;
+  config)
+    DIR="$(config_dir)"
+    case "$CONFIG_CMD" in
+      tracker) config_tracker "$DIR" "${CONFIG_ARGS[0]:-}" ;;
+      skills) config_skills "$DIR" ${CONFIG_ARGS[@]+"${CONFIG_ARGS[@]}"} ;;
+      *) config_show "$DIR" ;;
+    esac
     ;;
   feature|bug|docs)
     need_issue

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+unset FACTORY_SKIP_TICKET_COMMENT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
+cfg() {
+  FACTORY_WORKSPACE="$WS" "$FACTORY" config --repo widgets "$@"
+}
+
+# No config yet: github is the default tracker
+out="$(cfg)"
+grep -q "tracker github" <<< "$out" || fail "default tracker should be github, got: $out"
+
+# tracker linear requires a team key
+cfg tracker linear >/dev/null 2>&1 && fail "tracker linear without --team must fail"
+out="$(cfg tracker linear 2>&1 || true)"
+grep -qi "team" <<< "$out" || fail "linear without team should print a usage message, got: $out"
+
+# Invalid tracker fails with a usage message
+cfg tracker jira >/dev/null 2>&1 && fail "tracker jira must fail"
+out="$(cfg tracker jira 2>&1 || true)"
+grep -qi "github or linear" <<< "$out" || fail "invalid tracker should print a usage message, got: $out"
+
+# tracker linear --team ABC then config shows tracker linear, team ABC
+cfg tracker linear --team ABC >/dev/null
+out="$(cfg)"
+grep -q "tracker linear" <<< "$out" || fail "config should show tracker linear, got: $out"
+grep -q "team ABC" <<< "$out" || fail "config should show team ABC, got: $out"
+[[ -f "$WS/widgets/.factory/config" ]] || fail "tracker should be stored in .factory/config"
+
+# tracker github switches back and drops the team
+cfg tracker github >/dev/null
+out="$(cfg)"
+grep -q "tracker github" <<< "$out" || fail "config should show tracker github, got: $out"
+grep -q "team" <<< "$out" && fail "github tracker should not show a team, got: $out"
+
+# config skills writes entries to .factory/conventions in the #35 line format
+cfg skills "euc-go: Go services" "euc-sql: migrations" >/dev/null
+grep -qxF "euc-go: Go services" "$WS/widgets/.factory/conventions" || fail "conventions missing euc-go entry"
+grep -qxF "euc-sql: migrations" "$WS/widgets/.factory/conventions" || fail "conventions missing euc-sql entry"
+out="$(cfg)"
+grep -q "euc-go: Go services" <<< "$out" || fail "config should list euc-go skill, got: $out"
+grep -q "euc-sql: migrations" <<< "$out" || fail "config should list euc-sql skill, got: $out"
+
+# config skills with no entries fails with a usage message
+cfg skills >/dev/null 2>&1 && fail "config skills without entries must fail"
+
+# Rerunning skills replaces the list instead of appending duplicates
+cfg skills "euc-go: Go services" >/dev/null
+[[ "$(grep -cxF 'euc-go: Go services' "$WS/widgets/.factory/conventions")" == "1" ]] || fail "rerun must not duplicate entries"
+grep -q "euc-sql" "$WS/widgets/.factory/conventions" && fail "rerun should replace the skill list"
+
+# .factory/ stays out of source control via .git/info/exclude
+grep -qxF ".factory/" "$WS/widgets/.git/info/exclude" || fail ".factory/ missing from .git/info/exclude"
+cfg tracker github >/dev/null
+[[ "$(grep -cxF '.factory/' "$WS/widgets/.git/info/exclude")" == "1" ]] || fail ".factory/ excluded more than once"
+
+# config runs against the checkout itself when it is the workspace
+out="$(cd "$WS/widgets" && "$FACTORY" config)"
+grep -q "tracker github" <<< "$out" || fail "config should work from inside a checkout, got: $out"
+
+# README documents the subcommand
+grep -q "factory.sh config" "$ROOT/README.md" || fail "README missing factory.sh config"
+
+echo "ok config"

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -72,6 +72,34 @@ cfg tracker github >/dev/null
 out="$(cd "$WS/widgets" && "$FACTORY" config)"
 grep -q "tracker github" <<< "$out" || fail "config should work from inside a checkout, got: $out"
 
+# With FACTORY_WORKSPACE set, config without --repo targets the cwd checkout,
+# not the workspace sibling named after the origin remote
+mkdir -p "$WS/widgets-fork"
+git -C "$WS/widgets-fork" init -q
+git -C "$WS/widgets-fork" remote add origin "https://github.com/acme/widgets.git"
+before="$(cat "$WS/widgets/.factory/config")"
+(cd "$WS/widgets-fork" && FACTORY_WORKSPACE="$WS" "$FACTORY" config tracker linear --team FRK >/dev/null)
+grep -qxF "team=FRK" "$WS/widgets-fork/.factory/config" || fail "config from a checkout must write that checkout's .factory/config"
+[[ "$(cat "$WS/widgets/.factory/config")" == "$before" ]] || fail "config from widgets-fork must not touch widgets"
+
+# Explicit --repo still wins over the cwd
+(cd "$WS/widgets-fork" && FACTORY_WORKSPACE="$WS" "$FACTORY" config --repo widgets tracker github >/dev/null)
+grep -qxF "tracker=github" "$WS/widgets/.factory/config" || fail "--repo must target the named checkout"
+grep -qxF "team=FRK" "$WS/widgets-fork/.factory/config" || fail "--repo widgets must not touch widgets-fork"
+
+# Appending .factory/ must not glue onto an exclude file missing its trailing newline
+printf 'node_modules' > "$WS/widgets-fork/.git/info/exclude"
+(cd "$WS/widgets-fork" && FACTORY_WORKSPACE="$WS" "$FACTORY" config tracker github >/dev/null)
+grep -qxF "node_modules" "$WS/widgets-fork/.git/info/exclude" || fail "existing exclude patterns must survive the append"
+grep -qxF ".factory/" "$WS/widgets-fork/.git/info/exclude" || fail ".factory/ missing after newline-less append"
+(cd "$WS/widgets-fork" && FACTORY_WORKSPACE="$WS" "$FACTORY" config tracker github >/dev/null)
+[[ "$(grep -cxF '.factory/' "$WS/widgets-fork/.git/info/exclude")" == "1" ]] || fail ".factory/ appended twice after newline fix"
+
+# Skills entries must be one line in the "<skill-name>: <when>" format
+cfg skills "no-colon-entry" >/dev/null 2>&1 && fail "skills entry without ': ' must fail"
+cfg skills $'euc-go: one\nnot-an-entry' >/dev/null 2>&1 && fail "skills entry with a newline must fail"
+grep -qxF "euc-go: Go services" "$WS/widgets/.factory/conventions" || fail "rejected entries must not overwrite conventions"
+
 # README documents the subcommand
 grep -q "factory.sh config" "$ROOT/README.md" || fail "README missing factory.sh config"
 

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -100,6 +100,20 @@ cfg skills "no-colon-entry" >/dev/null 2>&1 && fail "skills entry without ': ' m
 cfg skills $'euc-go: one\nnot-an-entry' >/dev/null 2>&1 && fail "skills entry with a newline must fail"
 grep -qxF "euc-go: Go services" "$WS/widgets/.factory/conventions" || fail "rejected entries must not overwrite conventions"
 
+# Worktree checkouts (.git is a file) still get the .factory/ exclude
+mkdir -p "$WS/wtree"
+git -C "$WS/wtree" init -q
+git -C "$WS/wtree" remote add origin "https://github.com/acme/wtree.git"
+git -C "$WS/wtree" -c user.email=t@t.t -c user.name=t commit -q --allow-empty -m init
+git -C "$WS/wtree" worktree add -q "$WS/wtree/.worktrees/wt" -b wtb
+(cd "$WS/wtree/.worktrees/wt" && FACTORY_WORKSPACE="$WS" "$FACTORY" config tracker github >/dev/null)
+grep -qxF "tracker=github" "$WS/wtree/.worktrees/wt/.factory/config" || fail "worktree config must land in the worktree"
+[[ -z "$(git -C "$WS/wtree/.worktrees/wt" status --porcelain)" ]] || fail ".factory/ must be excluded in a worktree checkout"
+
+# Extra positional args are rejected, not silently dropped
+cfg tracker github linear >/dev/null 2>&1 && fail "config tracker with extra args must fail"
+grep -qxF "tracker=github" "$WS/widgets/.factory/config" || fail "rejected tracker args must not change config"
+
 # README documents the subcommand
 grep -q "factory.sh config" "$ROOT/README.md" || fail "README missing factory.sh config"
 


### PR DESCRIPTION
factory.sh config sets a checkout up without hand-editing: config tracker github|linear --team <key> stores the tracker in .factory/config, config skills writes .factory/conventions in the #35 line format, and bare config prints both. Both files stay untracked via .git/info/exclude, github is the default tracker, and invalid tracker or linear without a team fails with a usage message. tests/config.sh covers the acceptance criteria end to end.

Closes #43