### PR TITLE
Feat/36/review lane enforces conventions skill list

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Headless. Never merges.
 
 `factory.sh ship` is an alias of `floor`. QA URL is `--url` or `FACTORY_QA_URL`. `--yes` is for workers. Lead stays interactive for quiz and for `blocked`.
 
-Per-repo conventions: feature, bug, and docs lanes are always told to check for relevant skills before writing code. To steer them, author `.factory/conventions` in the target checkout. Each line is one of: `# comment`, `skill-name: when it applies` (a skill entry with context, e.g. `euc-go: Go services and migrations`), a bare `skill-name`, or any other text, injected verbatim as repo context (e.g. `never add jest tests; never raw HTML`). Any skill available to the runner can be listed; the lane is told to invoke each one that applies. factory.sh adds `.factory/` to the checkout's `.git/info/exclude` when it reads the file, which keeps an untracked file from being committed.
+Per-repo conventions: feature, bug, and docs lanes are always told to check for relevant skills before writing code. To steer them, author `.factory/conventions` in the target checkout. Each line is one of: `# comment`, `skill-name: when it applies` (a skill entry with context, e.g. `euc-go: Go services and migrations`), a bare `skill-name`, or any other text, injected verbatim as repo context (e.g. `never add jest tests; never raw HTML`). Any skill available to the runner can be listed; the lane is told to invoke each one that applies. The review lane gets the same list when the file exists and flags every convention violation as a review comment. factory.sh adds `.factory/` to the checkout's `.git/info/exclude` when it reads the file, which keeps an untracked file from being committed.
 
 ## What this pack will not do
 

--- a/factory.sh
+++ b/factory.sh
@@ -169,7 +169,7 @@ repo_dir() {
 }
 
 conventions_rules() {
-  local dir="$1" file="$1/.factory/conventions" line skills="" context=""
+  local dir="$1" lane="${2:-implement}" file="$1/.factory/conventions" line skills="" context=""
   if [[ -f "$file" ]]; then
     if [[ -d "$dir/.git" ]] && ! grep -qxF '.factory/' "$dir/.git/info/exclude" 2>/dev/null; then
       mkdir -p "$dir/.git/info"
@@ -188,8 +188,15 @@ conventions_rules() {
       fi
     done < "$file"
   fi
-  local out='Check for relevant skills before writing code and follow their conventions.'
-  [[ -z "$skills" ]] || out+=$'\n'"This repo enables these skills; invoke each one that applies before writing code:$skills"
+  local out
+  if [[ "$lane" == review ]]; then
+    [[ -n "$skills" || -n "$context" ]] || return 0
+    out='Check the diff against this repo'\''s conventions and flag every violation as a review comment.'
+    [[ -z "$skills" ]] || out+=$'\n'"This repo enables these skills; invoke each one that applies to the diff:$skills"
+  else
+    out='Check for relevant skills before writing code and follow their conventions.'
+    [[ -z "$skills" ]] || out+=$'\n'"This repo enables these skills; invoke each one that applies before writing code:$skills"
+  fi
   [[ -z "$context" ]] || out+=$'\n'"Repo context:$context"
   printf '%s\n' "$out"
 }
@@ -970,7 +977,10 @@ case "$LANE" in
   review)
     need_pr
     DIR="$(repo_dir)"
-    run_mem_lane review "$DIR" "$(cat "$FACTORY/lanes/review.md")"$'\n'"$HARD" "Review $(pr_url "$PR") only. Use /thermo-nuclear-code-quality-review. Do not implement. Do not merge."
+    RULES="$(cat "$FACTORY/lanes/review.md")"$'\n'"$HARD"
+    CONVENTIONS="$(conventions_rules "$DIR" review)"
+    [[ -z "$CONVENTIONS" ]] || RULES+=$'\n'"$CONVENTIONS"
+    run_mem_lane review "$DIR" "$RULES" "Review $(pr_url "$PR") only. Use /thermo-nuclear-code-quality-review. Do not implement. Do not merge."
     exit $?
     ;;
   ci)

--- a/factory.sh
+++ b/factory.sh
@@ -169,7 +169,7 @@ repo_dir() {
 }
 
 conventions_rules() {
-  local dir="$1" lane="${2:-implement}" file="$1/.factory/conventions" line skills="" context=""
+  local dir="$1" file="$1/.factory/conventions" line skills="" context=""
   if [[ -f "$file" ]]; then
     if [[ -d "$dir/.git" ]] && ! grep -qxF '.factory/' "$dir/.git/info/exclude" 2>/dev/null; then
       mkdir -p "$dir/.git/info"
@@ -188,17 +188,10 @@ conventions_rules() {
       fi
     done < "$file"
   fi
-  local out
-  if [[ "$lane" == review ]]; then
-    [[ -n "$skills" || -n "$context" ]] || return 0
-    out='Check the diff against this repo'\''s conventions and flag every violation as a review comment.'
-    [[ -z "$skills" ]] || out+=$'\n'"This repo enables these skills; invoke each one that applies to the diff:$skills"
-  else
-    out='Check for relevant skills before writing code and follow their conventions.'
-    [[ -z "$skills" ]] || out+=$'\n'"This repo enables these skills; invoke each one that applies before writing code:$skills"
-  fi
-  [[ -z "$context" ]] || out+=$'\n'"Repo context:$context"
-  printf '%s\n' "$out"
+  local out=''
+  [[ -z "$skills" ]] || out="This repo enables these skills; invoke each one that applies:$skills"$'\n'
+  [[ -z "$context" ]] || out+="Repo context:$context"$'\n'
+  [[ -z "$out" ]] || printf '%s' "$out"
 }
 
 run_agent() {
@@ -978,7 +971,7 @@ case "$LANE" in
     need_pr
     DIR="$(repo_dir)"
     RULES="$(cat "$FACTORY/lanes/review.md")"$'\n'"$HARD"
-    CONVENTIONS="$(conventions_rules "$DIR" review)"
+    CONVENTIONS="$(conventions_rules "$DIR")"
     [[ -z "$CONVENTIONS" ]] || RULES+=$'\n'"$CONVENTIONS"
     run_mem_lane review "$DIR" "$RULES" "Review $(pr_url "$PR") only. Use /thermo-nuclear-code-quality-review. Do not implement. Do not merge."
     exit $?

--- a/lanes/bug.md
+++ b/lanes/bug.md
@@ -6,6 +6,7 @@ Ask Telemetry for evidence if it is not already in the ticket.
 If this is a web application bug, reproduce it in a real browser with /browser-use before you write a test. Screenshot the failure. If login is required, hand that step to a human. Never read .env.
 If there is no browser, say so and fall back to ticket steps plus a failing test.
 Then TDD fix. Follow /tdd, /implement, /unslop.
+Check for relevant skills before writing code and follow their conventions.
 Work only on the ticket in this prompt. New branch off main.
 Never merge. Never touch other PRs.
 When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/docs.md
+++ b/lanes/docs.md
@@ -3,5 +3,6 @@ You are the factory Docs lane.
 At start, factory.sh mem read for this issue. Write started only if that read shows no in-progress docs run. Missing memory: warn once and continue.
 
 Docs only. No application code. Short pages, tables, mermaid, decisions, file paths, PR links.
+Check for relevant skills before writing code and follow their conventions.
 Never merge. Never read .env.
 When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/lanes/feature.md
+++ b/lanes/feature.md
@@ -3,6 +3,7 @@ You are the factory Feature lane.
 At start, factory.sh mem read for this issue. Write started only if that read shows no in-progress feature run. Missing memory: warn once and continue.
 
 Do not expand the ask. Follow /tdd, /implement, /unslop.
+Check for relevant skills before writing code and follow their conventions.
 If the ticket came from a funnel or feature-performance signal, keep the change on that path.
 Work only on the ticket in this prompt. New branch off main.
 Never merge. Never read .env. Never touch other PRs.

--- a/lanes/review.md
+++ b/lanes/review.md
@@ -3,5 +3,6 @@ You are the factory Reviewer.
 At start, factory.sh mem read for this PR. Write started only if that read shows no in-progress review run. Missing memory: warn once and continue.
 
 Run /thermo-nuclear-code-quality-review on the given PR only.
+If the rules list this repo's conventions skills, invoke each listed skill and flag every violation of its conventions as a review comment.
 Do not implement. Do not merge. Leave GitHub review comments.
 When your job is done, factory.sh mem write done, blocked, or failed from the outcome. Then report back to Tech lead: what you did, PR or issue URL, evidence, what should happen next. Do not dispatch the next lane yourself.

--- a/tests/conventions.sh
+++ b/tests/conventions.sh
@@ -49,11 +49,28 @@ run_lane() {
     "$FACTORY" "$lane" --repo widgets --issue 6 >/dev/null 2>&1
 }
 
+run_review() {
+  PATH="$TMP/bin:$PATH" \
+    FAKE_DUMP="$DUMP" \
+    FACTORY_WORKSPACE="$WS" \
+    FACTORY_OWNER=acme \
+    FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
+    "$FACTORY" review --repo widgets --pr 6 >/dev/null 2>&1
+}
+
 # Missing conventions file: the generic skill-check instruction is still injected
 run_lane feature
 [[ -f "$DUMP/rules" ]] || fail "feature should run without conventions file"
 grep -q "Check for relevant skills before writing code" "$DUMP/rules" || fail "missing file must still inject the generic skill-check instruction"
 grep -q "This repo enables these skills" "$DUMP/rules" && fail "missing file must not inject a skill list"
+
+# Missing conventions file: review rules get no conventions injection at all
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+run_review
+[[ -f "$DUMP/rules" ]] || fail "review should run without conventions file"
+grep -q "This repo enables these skills" "$DUMP/rules" && fail "review must not get a skill list without a conventions file"
+grep -q "Check for relevant skills before writing code" "$DUMP/rules" && fail "review must not get the implementing-lane instruction"
 
 # Conventions file: skill entries with context and repo context reach every implementing lane
 mkdir -p "$WS/widgets/.factory"
@@ -73,6 +90,21 @@ for lane in feature bug docs; do
   grep -qi "invoke" "$DUMP/rules" || fail "$lane rules missing invoke instruction"
   grep -q "tooling notes" "$DUMP/rules" && fail "$lane rules must not include comment lines"
 done
+
+# Conventions file: the review lane gets the skill list and flags violations as comments
+rm -rf "$DUMP"
+mkdir -p "$DUMP"
+run_review
+grep -q "/go-style: services and migrations" "$DUMP/rules" || fail "review rules missing go-style with its context"
+grep -q "/web-style: web frontends" "$DUMP/rules" || fail "review rules missing web-style with its context"
+grep -q "never add jest tests; never raw HTML" "$DUMP/rules" || fail "review rules missing repo context line"
+grep -q "review comment" "$DUMP/rules" || fail "review rules missing flag-as-comment instruction"
+grep -q "Check for relevant skills before writing code" "$DUMP/rules" && fail "review rules must not carry the implementing-lane instruction"
+grep -q "tooling notes" "$DUMP/rules" && fail "review rules must not include comment lines"
+
+# The review lane playbook tells the reviewer to enforce listed conventions
+grep -qi "invoke" "$ROOT/lanes/review.md" || fail "review.md missing invoke instruction"
+grep -qi "convention" "$ROOT/lanes/review.md" || fail "review.md missing conventions instruction"
 
 # Reading the file excludes .factory/ from source control
 grep -qxF ".factory/" "$WS/widgets/.git/info/exclude" || fail ".factory/ missing from .git/info/exclude"

--- a/tests/conventions.sh
+++ b/tests/conventions.sh
@@ -39,27 +39,17 @@ exit 0
 EOF
 chmod +x "$TMP/bin/gh"
 
-run_lane() {
-  local lane="$1"
+run_factory() {
   PATH="$TMP/bin:$PATH" \
     FAKE_DUMP="$DUMP" \
     FACTORY_WORKSPACE="$WS" \
     FACTORY_OWNER=acme \
     FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
-    "$FACTORY" "$lane" --repo widgets --issue 6 >/dev/null 2>&1
-}
-
-run_review() {
-  PATH="$TMP/bin:$PATH" \
-    FAKE_DUMP="$DUMP" \
-    FACTORY_WORKSPACE="$WS" \
-    FACTORY_OWNER=acme \
-    FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
-    "$FACTORY" review --repo widgets --pr 6 >/dev/null 2>&1
+    "$FACTORY" "$@" --repo widgets >/dev/null 2>&1
 }
 
 # Missing conventions file: the generic skill-check instruction is still injected
-run_lane feature
+run_factory feature --issue 6
 [[ -f "$DUMP/rules" ]] || fail "feature should run without conventions file"
 grep -q "Check for relevant skills before writing code" "$DUMP/rules" || fail "missing file must still inject the generic skill-check instruction"
 grep -q "This repo enables these skills" "$DUMP/rules" && fail "missing file must not inject a skill list"
@@ -67,7 +57,7 @@ grep -q "This repo enables these skills" "$DUMP/rules" && fail "missing file mus
 # Missing conventions file: review rules get no conventions injection at all
 rm -rf "$DUMP"
 mkdir -p "$DUMP"
-run_review
+run_factory review --pr 6
 [[ -f "$DUMP/rules" ]] || fail "review should run without conventions file"
 grep -q "This repo enables these skills" "$DUMP/rules" && fail "review must not get a skill list without a conventions file"
 grep -q "Check for relevant skills before writing code" "$DUMP/rules" && fail "review must not get the implementing-lane instruction"
@@ -83,21 +73,23 @@ CONV
 for lane in feature bug docs; do
   rm -rf "$DUMP"
   mkdir -p "$DUMP"
-  run_lane "$lane"
+  run_factory "$lane" --issue 6
   grep -q "/go-style: services and migrations" "$DUMP/rules" || fail "$lane rules missing go-style with its context"
   grep -q "/web-style: web frontends" "$DUMP/rules" || fail "$lane rules missing web-style with its context"
   grep -q "never add jest tests; never raw HTML" "$DUMP/rules" || fail "$lane rules missing repo context line"
-  grep -qi "invoke" "$DUMP/rules" || fail "$lane rules missing invoke instruction"
+  grep -q "invoke each one that applies:" "$DUMP/rules" || fail "$lane rules missing the lane-neutral skill-list header"
+  grep -q "Check for relevant skills before writing code" "$DUMP/rules" || fail "$lane rules missing the implementing-lane instruction"
   grep -q "tooling notes" "$DUMP/rules" && fail "$lane rules must not include comment lines"
 done
 
-# Conventions file: the review lane gets the skill list and flags violations as comments
+# Conventions file: the review lane gets the same skill list and flags violations as comments
 rm -rf "$DUMP"
 mkdir -p "$DUMP"
-run_review
+run_factory review --pr 6
 grep -q "/go-style: services and migrations" "$DUMP/rules" || fail "review rules missing go-style with its context"
 grep -q "/web-style: web frontends" "$DUMP/rules" || fail "review rules missing web-style with its context"
 grep -q "never add jest tests; never raw HTML" "$DUMP/rules" || fail "review rules missing repo context line"
+grep -q "invoke each one that applies:" "$DUMP/rules" || fail "review rules missing the lane-neutral skill-list header"
 grep -q "review comment" "$DUMP/rules" || fail "review rules missing flag-as-comment instruction"
 grep -q "Check for relevant skills before writing code" "$DUMP/rules" && fail "review rules must not carry the implementing-lane instruction"
 grep -q "tooling notes" "$DUMP/rules" && fail "review rules must not include comment lines"
@@ -108,21 +100,21 @@ grep -qi "convention" "$ROOT/lanes/review.md" || fail "review.md missing convent
 
 # Reading the file excludes .factory/ from source control
 grep -qxF ".factory/" "$WS/widgets/.git/info/exclude" || fail ".factory/ missing from .git/info/exclude"
-run_lane feature
+run_factory feature --issue 6
 [[ "$(grep -cxF '.factory/' "$WS/widgets/.git/info/exclude")" == "1" ]] || fail ".factory/ excluded more than once"
 
 # Blank lines are skipped and a bare skill name needs no context
 printf '\nsql-style\n\n' > "$WS/widgets/.factory/conventions"
 rm -rf "$DUMP"
 mkdir -p "$DUMP"
-run_lane feature
+run_factory feature --issue 6
 grep -q "/sql-style" "$DUMP/rules" || fail "rules missing bare skill sql-style"
 
 # Empty file behaves like a missing file
 : > "$WS/widgets/.factory/conventions"
 rm -rf "$DUMP"
 mkdir -p "$DUMP"
-run_lane feature
+run_factory feature --issue 6
 grep -q "Check for relevant skills before writing code" "$DUMP/rules" || fail "empty file must still inject the generic skill-check instruction"
 grep -q "This repo enables these skills" "$DUMP/rules" && fail "empty conventions file must not inject a skill list"
 


### PR DESCRIPTION
The review lane now gets the .factory/conventions skill list in its rules whenever the file exists in the target checkout, phrased for reviewing: invoke each listed skill and flag every violation as a review comment. lanes/review.md carries the matching instruction, and tests/conventions.sh covers both the injected rules and the missing-file case. Closes #36.