### PR TITLE
Feat/49/factory setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The runner is a plug. Grok, Claude Code, Codex, Cursor. Same `AGENTS.md`, same s
 
 Telemetry is a plug too. Not an error inbox. It answers whether a path broke or a feature died: signup, onboarding, checkout, invite, the core loop, a shipped screen nobody finishes. PostHog, Datadog, Azure App Insights, and CloudWatch all speak [`telemetry/CONTRACT.md`](telemetry/CONTRACT.md). Swap the vendor. Keep the questions.
 
+
 ![Software factory](docs/factory.png)
 
 
@@ -90,6 +91,7 @@ That creates `~/.factory/memory`, installs the plugin, and puts `factory` on `~/
 
 ```bash
 cd /path/to/your-checkout
+factory setup
 grok          # or claude
 /lead
 ```
@@ -141,12 +143,15 @@ Headless. Never merges.
 ./factory.sh qa --repo frontend --pr 12 --url http://localhost:3000
 ./factory.sh mem write --lane feature --status started --issue 12 --harness grok --summary "Add the memory store"
 ./factory.sh mem read --issue 12
+./factory.sh setup
 ./factory.sh config tracker linear --team ABC
 ./factory.sh config skills "euc-go: Go services" "euc-sql: migrations"
 ./factory.sh config
 ```
 
-`factory.sh config` sets a checkout up for the factory without hand-editing files. `config tracker github|linear [--team <linear-team-key>]` stores the issue tracker in `.factory/config`; github is the default when no config exists, and linear requires a team key. `config skills "<skill-name>: <when it applies>" [more...]` replaces `.factory/conventions` with those entries, one per line. `config` with no arguments prints the current tracker and skills. It targets `--repo <name>` under the workspace, or the checkout you run it from. Both files live under `.factory/`, which factory.sh adds to the checkout's `.git/info/exclude` so they stay out of source control.
+`factory setup` is the human path. From a product checkout it walks tracker and skills one stage at a time, shows a review, then writes through the same files as `factory.sh config`. Existing config is detected so you can update or keep it. Skip a section to keep the default. Cancel at the review leaves files unchanged. It needs a terminal; `NO_COLOR` or a dumb terminal stays usable without color or animation. No TTY: it prints the current config and exits. `--yes` is for workers, not this wizard.
+
+`factory.sh config` is the scriptable writer. `config tracker github|linear [--team <linear-team-key>]` stores the issue tracker in `.factory/config`; github is the default when no config exists, and linear requires a team key. `config skills "<skill-name>: <when it applies>" [more...]` replaces `.factory/conventions` with those entries, one per line. `config` with no arguments prints the current tracker and skills. It targets `--repo <name>` under the workspace, or the checkout you run it from. Both files live under `.factory/`, which factory.sh adds to the checkout's `.git/info/exclude` so they stay out of source control.
 
 `factory.sh ship` is an alias of `floor`. QA URL is `--url` or `FACTORY_QA_URL`. `--yes` is for workers. Lead stays interactive for quiz and for `blocked`.
 

--- a/factory.sh
+++ b/factory.sh
@@ -19,6 +19,7 @@ Usage:
   factory.sh config           [--repo <name>]  prints the current tracker and skills
   factory.sh config tracker   github|linear [--team <linear-team-key>] [--repo <name>]
   factory.sh config skills    "<skill-name>: <when it applies>" [more...] [--repo <name>]
+  factory.sh setup            [--repo <name>]  interactive setup for tracker and skills
   factory.sh mem read         [--issue <n>] [--pr <n>] [--project owner/name] [--limit n]
   factory.sh mem write        --lane <lane> --status started|done|blocked|failed [--harness claude|codex|cursor|grok] [--issue <n>] [--pr <n>] [--project owner/name] [--summary s] [--next-steps s] [--evidence url-or-json]
   factory.sh close-linked     --pr <n> [--repo name] [--owner org]
@@ -99,6 +100,19 @@ if [[ "$LANE" == "config" ]]; then
           usage
         fi
         shift ;;
+    esac
+  done
+elif [[ "$LANE" == "setup" ]]; then
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) REPO="${2:-}"; CONFIG_REPO_FLAG=1; shift 2 ;;
+      --yes)
+        echo "factory setup is interactive. Use factory.sh config for scripts." >&2
+        exit 1
+        ;;
+      -h|--help) usage ;;
+      --*) echo "Unknown arg: $1" >&2; usage ;;
+      *) echo "Unknown arg: $1" >&2; usage ;;
     esac
   done
 elif [[ "$LANE" == "mem" ]]; then
@@ -257,6 +271,18 @@ config_tracker() {
   config_show "$dir"
 }
 
+config_write_conventions() {
+  local dir="$1"
+  shift
+  mkdir -p "$dir/.factory"
+  factory_exclude "$dir"
+  if [[ $# -eq 0 ]]; then
+    : > "$dir/.factory/conventions"
+  else
+    printf '%s\n' "$@" > "$dir/.factory/conventions"
+  fi
+}
+
 config_skills() {
   local dir="$1" entry
   shift
@@ -264,10 +290,270 @@ config_skills() {
   for entry in "$@"; do
     [[ "$entry" == *": "* && "$entry" != *$'\n'* ]] || { echo "Skills entries are one line each: \"<skill-name>: <when it applies>\", got: $entry" >&2; exit 1; }
   done
-  mkdir -p "$dir/.factory"
-  factory_exclude "$dir"
-  printf '%s\n' "$@" > "$dir/.factory/conventions"
+  config_write_conventions "$dir" "$@"
   config_show "$dir"
+}
+
+SETUP_TOTAL=5
+SETUP_INDEX=0
+SETUP_COLOR=0
+SETUP_ANIM=0
+SETUP_BOLD=""
+SETUP_DIM=""
+SETUP_RESET=""
+SETUP_CYAN=""
+SETUP_GREEN=""
+SETUP_YELLOW=""
+SETUP_TRACKER="github"
+SETUP_TEAM=""
+SETUP_LINES=()
+SETUP_SKILLS_CHANGED=0
+
+setup_init_ui() {
+  SETUP_COLOR=0
+  SETUP_ANIM=0
+  SETUP_BOLD=""
+  SETUP_DIM=""
+  SETUP_RESET=""
+  SETUP_CYAN=""
+  SETUP_GREEN=""
+  SETUP_YELLOW=""
+  [[ -z "${NO_COLOR:-}" && "${TERM:-dumb}" != "dumb" && -t 1 ]] || return 0
+  command -v tput >/dev/null 2>&1 || return 0
+  local colors
+  colors="$(tput colors 2>/dev/null || echo 0)"
+  [[ "$colors" -ge 8 ]] || return 0
+  SETUP_COLOR=1
+  SETUP_ANIM=1
+  SETUP_BOLD="$(tput bold 2>/dev/null || true)"
+  SETUP_DIM="$(tput dim 2>/dev/null || true)"
+  SETUP_RESET="$(tput sgr0 2>/dev/null || true)"
+  SETUP_CYAN="$(tput setaf 6 2>/dev/null || true)"
+  SETUP_GREEN="$(tput setaf 2 2>/dev/null || true)"
+  SETUP_YELLOW="$(tput setaf 3 2>/dev/null || true)"
+}
+
+setup_need_tty() {
+  local dir="$1"
+  if [[ -t 0 && -t 1 ]]; then
+    return 0
+  fi
+  echo "factory setup needs a terminal. Use factory.sh config for scripts." >&2
+  config_show "$dir" >&2
+  exit 1
+}
+
+setup_clear() {
+  [[ -t 1 && "${TERM:-dumb}" != "dumb" ]] || return 0
+  if command -v tput >/dev/null 2>&1; then
+    tput clear 2>/dev/null || printf '\033[2J\033[H'
+  else
+    printf '\033[2J\033[H'
+  fi
+}
+
+setup_transition() {
+  [[ "$SETUP_ANIM" -eq 1 ]] || return 0
+  local i
+  for i in 1 2 3; do
+    printf '\r  %s·  %s' "$SETUP_DIM" "$SETUP_RESET"
+    sleep 0.04
+    printf '\r  %s·· %s' "$SETUP_DIM" "$SETUP_RESET"
+    sleep 0.04
+    printf '\r  %s···%s' "$SETUP_DIM" "$SETUP_RESET"
+    sleep 0.04
+    printf '\r     \r'
+  done
+}
+
+setup_stage() {
+  local name="$1"
+  setup_transition
+  setup_clear
+  SETUP_INDEX=$((SETUP_INDEX + 1))
+  printf '\n%s%s▸ %s/%s  %s%s\n\n' "$SETUP_BOLD" "$SETUP_CYAN" "$SETUP_INDEX" "$SETUP_TOTAL" "$name" "$SETUP_RESET"
+}
+
+setup_spin() {
+  local msg="$1"
+  if [[ "$SETUP_ANIM" -ne 1 ]]; then
+    printf '  %s\n' "$msg"
+    return
+  fi
+  local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏') i
+  for i in 0 1 2 3 4 5 6 7; do
+    printf '\r  %s%s%s %s' "$SETUP_CYAN" "${frames[i]}" "$SETUP_RESET" "$msg"
+    sleep 0.04
+  done
+  printf '\r\033[K'
+}
+
+setup_read() {
+  local prompt="$1" varname="$2" default="${3:-}" input=""
+  if [[ -n "$default" ]]; then
+    printf '  %s%s%s [%s]: ' "$SETUP_BOLD" "$prompt" "$SETUP_RESET" "$default"
+  else
+    printf '  %s%s%s: ' "$SETUP_BOLD" "$prompt" "$SETUP_RESET"
+  fi
+  if ! IFS= read -r input; then
+    echo "factory setup needs a terminal." >&2
+    exit 1
+  fi
+  input="${input%$'\r'}"
+  input="${input#"${input%%[![:space:]]*}"}"
+  input="${input%"${input##*[![:space:]]}"}"
+  if [[ -z "$input" && -n "$default" ]]; then
+    input="$default"
+  fi
+  printf -v "$varname" '%s' "$input"
+}
+
+setup_read_existing() {
+  local dir="$1" tracker="github" team="" line
+  SETUP_TRACKER="github"
+  SETUP_TEAM=""
+  SETUP_LINES=()
+  SETUP_SKILLS_CHANGED=0
+  if [[ -f "$dir/.factory/config" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      case "$line" in
+        tracker=*) tracker="${line#tracker=}" ;;
+        team=*) team="${line#team=}" ;;
+      esac
+    done < "$dir/.factory/config"
+    SETUP_TRACKER="$tracker"
+    SETUP_TEAM="$team"
+  fi
+  if [[ -s "$dir/.factory/conventions" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -n "$line" ]] && SETUP_LINES+=("$line")
+    done < "$dir/.factory/conventions"
+  fi
+}
+
+setup_has_existing() {
+  local dir="$1"
+  [[ -f "$dir/.factory/config" || -s "$dir/.factory/conventions" ]]
+}
+
+setup_fold() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+setup_write() {
+  local dir="$1"
+  if [[ "$SETUP_TRACKER" == linear ]]; then
+    TEAM="$SETUP_TEAM" config_tracker "$dir" linear >/dev/null
+  else
+    TEAM="" config_tracker "$dir" github >/dev/null
+  fi
+  if [[ "$SETUP_SKILLS_CHANGED" -eq 1 ]]; then
+    config_write_conventions "$dir" ${SETUP_LINES[@]+"${SETUP_LINES[@]}"}
+  fi
+  config_show "$dir"
+}
+
+setup_run() {
+  local dir="$1" choice="" tracker_in="" team_in="" line="" confirm="" skill
+  setup_need_tty "$dir"
+  setup_init_ui
+  SETUP_TOTAL=5
+  SETUP_INDEX=0
+  setup_read_existing "$dir"
+
+  setup_stage "Detect"
+  setup_spin "Looking for factory config"
+  if setup_has_existing "$dir"; then
+    printf '  Existing factory config:\n'
+    config_show "$dir" | sed 's/^/  /'
+    printf '\n'
+    while true; do
+      setup_read "Update or keep?" choice "update"
+      case "$(setup_fold "$choice")" in
+        k|keep)
+          printf '\n  Kept existing config.\n'
+          config_show "$dir"
+          return 0
+          ;;
+        u|update) break ;;
+        *) printf '  Type update or keep.\n' ;;
+      esac
+    done
+  else
+    printf '  No factory config yet.\n'
+  fi
+
+  setup_stage "Tracker"
+  printf '  github (default) or linear, which needs a team key.\n'
+  printf '  skip keeps the current tracker.\n\n'
+  while true; do
+    setup_read "Tracker (github, linear, skip)" tracker_in "$SETUP_TRACKER"
+    case "$(setup_fold "$tracker_in")" in
+      s|skip) break ;;
+      github)
+        SETUP_TRACKER="github"
+        SETUP_TEAM=""
+        break
+        ;;
+      linear)
+        while true; do
+          setup_read "Linear team key" team_in "${SETUP_TEAM}"
+          if [[ -n "$team_in" ]]; then
+            SETUP_TRACKER="linear"
+            SETUP_TEAM="$team_in"
+            break
+          fi
+          printf '  Linear needs a team key.\n'
+        done
+        break
+        ;;
+      *) printf '  Choose github, linear, or skip.\n' ;;
+    esac
+  done
+
+  setup_stage "Skills"
+  printf '  Factory skills:\n'
+  for skill in "$FACTORY"/skills/*; do
+    [[ -d "$skill" ]] || continue
+    printf '    %s\n' "${skill##*/}"
+  done
+  printf '\n  One line: "<skill>: <when it applies>" or a convention.\n'
+  printf '  Empty line skips or finishes.\n\n'
+  local collected=()
+  while true; do
+    setup_read "Skill or convention" line
+    [[ -n "$line" ]] || break
+    collected+=("$line")
+  done
+  if (( ${#collected[@]} > 0 )); then
+    SETUP_LINES=("${collected[@]}")
+    SETUP_SKILLS_CHANGED=1
+  fi
+
+  setup_stage "Review"
+  printf '  Tracker: %s\n' "$SETUP_TRACKER"
+  [[ -z "$SETUP_TEAM" ]] || printf '  Team: %s\n' "$SETUP_TEAM"
+  if (( ${#SETUP_LINES[@]} > 0 )); then
+    printf '  Skills:\n'
+    for line in "${SETUP_LINES[@]}"; do
+      printf '    %s\n' "$line"
+    done
+  else
+    printf '  Skills: none\n'
+  fi
+  printf '\n'
+  setup_read "Write this config? [y/N]" confirm
+  case "$(setup_fold "$confirm")" in
+    y|yes) ;;
+    *)
+      printf '\n  Canceled. Nothing written.\n'
+      exit 1
+      ;;
+  esac
+
+  setup_stage "Write"
+  setup_write "$dir"
+  printf '\n  %sWrote factory config.%s\n' "$SETUP_GREEN" "$SETUP_RESET"
 }
 
 conventions_rules() {
@@ -1067,6 +1353,11 @@ case "$LANE" in
       skills) config_skills "$DIR" ${CONFIG_ARGS[@]+"${CONFIG_ARGS[@]}"} ;;
       *) config_show "$DIR" ;;
     esac
+    ;;
+  setup)
+    DIR="$(config_dir)"
+    setup_run "$DIR"
+    exit $?
     ;;
   feature|bug|docs)
     need_issue

--- a/factory.sh
+++ b/factory.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 
 FACTORY="$(cd "$(dirname "$0")" && pwd)"
+if [[ -L "$0" ]]; then
+  _factory_target="$(readlink "$0" 2>/dev/null || true)"
+  if [[ -n "$_factory_target" ]]; then
+    [[ "$_factory_target" == /* ]] || _factory_target="$FACTORY/$_factory_target"
+    FACTORY="$(cd "$(dirname "$_factory_target")" && pwd)"
+  fi
+  unset _factory_target
+fi
 WORKSPACE="${FACTORY_WORKSPACE:-$PWD}"
 OWNER="${FACTORY_OWNER:-}"
 RUNNER="${FACTORY_RUNNER:-}"
@@ -234,21 +242,37 @@ factory_exclude() {
   printf '.factory/\n' >> "$exclude"
 }
 
-config_show() {
-  local dir="$1" tracker="github" team="" line
+config_read() {
+  local dir="$1" line
+  CONFIG_TRACKER="github"
+  CONFIG_TEAM=""
+  CONFIG_LINES=()
+  CONFIG_EXISTS=0
   if [[ -f "$dir/.factory/config" ]]; then
+    CONFIG_EXISTS=1
     while IFS= read -r line || [[ -n "$line" ]]; do
       case "$line" in
-        tracker=*) tracker="${line#tracker=}" ;;
-        team=*) team="${line#team=}" ;;
+        tracker=*) CONFIG_TRACKER="${line#tracker=}" ;;
+        team=*) CONFIG_TEAM="${line#team=}" ;;
       esac
     done < "$dir/.factory/config"
   fi
-  printf 'tracker %s\n' "$tracker"
-  [[ -z "$team" ]] || printf 'team %s\n' "$team"
   if [[ -s "$dir/.factory/conventions" ]]; then
+    CONFIG_EXISTS=1
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -n "$line" ]] && CONFIG_LINES+=("$line")
+    done < "$dir/.factory/conventions"
+  fi
+}
+
+config_show() {
+  local dir="$1"
+  config_read "$dir"
+  printf 'tracker %s\n' "$CONFIG_TRACKER"
+  [[ -z "$CONFIG_TEAM" ]] || printf 'team %s\n' "$CONFIG_TEAM"
+  if (( ${#CONFIG_LINES[@]} > 0 )); then
     printf 'skills:\n'
-    cat "$dir/.factory/conventions"
+    printf '%s\n' "${CONFIG_LINES[@]}"
   else
     printf 'skills: none\n'
   fi
@@ -292,268 +316,6 @@ config_skills() {
   done
   config_write_conventions "$dir" "$@"
   config_show "$dir"
-}
-
-SETUP_TOTAL=5
-SETUP_INDEX=0
-SETUP_COLOR=0
-SETUP_ANIM=0
-SETUP_BOLD=""
-SETUP_DIM=""
-SETUP_RESET=""
-SETUP_CYAN=""
-SETUP_GREEN=""
-SETUP_YELLOW=""
-SETUP_TRACKER="github"
-SETUP_TEAM=""
-SETUP_LINES=()
-SETUP_SKILLS_CHANGED=0
-
-setup_init_ui() {
-  SETUP_COLOR=0
-  SETUP_ANIM=0
-  SETUP_BOLD=""
-  SETUP_DIM=""
-  SETUP_RESET=""
-  SETUP_CYAN=""
-  SETUP_GREEN=""
-  SETUP_YELLOW=""
-  [[ -z "${NO_COLOR:-}" && "${TERM:-dumb}" != "dumb" && -t 1 ]] || return 0
-  command -v tput >/dev/null 2>&1 || return 0
-  local colors
-  colors="$(tput colors 2>/dev/null || echo 0)"
-  [[ "$colors" -ge 8 ]] || return 0
-  SETUP_COLOR=1
-  SETUP_ANIM=1
-  SETUP_BOLD="$(tput bold 2>/dev/null || true)"
-  SETUP_DIM="$(tput dim 2>/dev/null || true)"
-  SETUP_RESET="$(tput sgr0 2>/dev/null || true)"
-  SETUP_CYAN="$(tput setaf 6 2>/dev/null || true)"
-  SETUP_GREEN="$(tput setaf 2 2>/dev/null || true)"
-  SETUP_YELLOW="$(tput setaf 3 2>/dev/null || true)"
-}
-
-setup_need_tty() {
-  local dir="$1"
-  if [[ -t 0 && -t 1 ]]; then
-    return 0
-  fi
-  echo "factory setup needs a terminal. Use factory.sh config for scripts." >&2
-  config_show "$dir" >&2
-  exit 1
-}
-
-setup_clear() {
-  [[ -t 1 && "${TERM:-dumb}" != "dumb" ]] || return 0
-  if command -v tput >/dev/null 2>&1; then
-    tput clear 2>/dev/null || printf '\033[2J\033[H'
-  else
-    printf '\033[2J\033[H'
-  fi
-}
-
-setup_transition() {
-  [[ "$SETUP_ANIM" -eq 1 ]] || return 0
-  local i
-  for i in 1 2 3; do
-    printf '\r  %s·  %s' "$SETUP_DIM" "$SETUP_RESET"
-    sleep 0.04
-    printf '\r  %s·· %s' "$SETUP_DIM" "$SETUP_RESET"
-    sleep 0.04
-    printf '\r  %s···%s' "$SETUP_DIM" "$SETUP_RESET"
-    sleep 0.04
-    printf '\r     \r'
-  done
-}
-
-setup_stage() {
-  local name="$1"
-  setup_transition
-  setup_clear
-  SETUP_INDEX=$((SETUP_INDEX + 1))
-  printf '\n%s%s▸ %s/%s  %s%s\n\n' "$SETUP_BOLD" "$SETUP_CYAN" "$SETUP_INDEX" "$SETUP_TOTAL" "$name" "$SETUP_RESET"
-}
-
-setup_spin() {
-  local msg="$1"
-  if [[ "$SETUP_ANIM" -ne 1 ]]; then
-    printf '  %s\n' "$msg"
-    return
-  fi
-  local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏') i
-  for i in 0 1 2 3 4 5 6 7; do
-    printf '\r  %s%s%s %s' "$SETUP_CYAN" "${frames[i]}" "$SETUP_RESET" "$msg"
-    sleep 0.04
-  done
-  printf '\r\033[K'
-}
-
-setup_read() {
-  local prompt="$1" varname="$2" default="${3:-}" input=""
-  if [[ -n "$default" ]]; then
-    printf '  %s%s%s [%s]: ' "$SETUP_BOLD" "$prompt" "$SETUP_RESET" "$default"
-  else
-    printf '  %s%s%s: ' "$SETUP_BOLD" "$prompt" "$SETUP_RESET"
-  fi
-  if ! IFS= read -r input; then
-    echo "factory setup needs a terminal." >&2
-    exit 1
-  fi
-  input="${input%$'\r'}"
-  input="${input#"${input%%[![:space:]]*}"}"
-  input="${input%"${input##*[![:space:]]}"}"
-  if [[ -z "$input" && -n "$default" ]]; then
-    input="$default"
-  fi
-  printf -v "$varname" '%s' "$input"
-}
-
-setup_read_existing() {
-  local dir="$1" tracker="github" team="" line
-  SETUP_TRACKER="github"
-  SETUP_TEAM=""
-  SETUP_LINES=()
-  SETUP_SKILLS_CHANGED=0
-  if [[ -f "$dir/.factory/config" ]]; then
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      case "$line" in
-        tracker=*) tracker="${line#tracker=}" ;;
-        team=*) team="${line#team=}" ;;
-      esac
-    done < "$dir/.factory/config"
-    SETUP_TRACKER="$tracker"
-    SETUP_TEAM="$team"
-  fi
-  if [[ -s "$dir/.factory/conventions" ]]; then
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      [[ -n "$line" ]] && SETUP_LINES+=("$line")
-    done < "$dir/.factory/conventions"
-  fi
-}
-
-setup_has_existing() {
-  local dir="$1"
-  [[ -f "$dir/.factory/config" || -s "$dir/.factory/conventions" ]]
-}
-
-setup_fold() {
-  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
-}
-
-setup_write() {
-  local dir="$1"
-  if [[ "$SETUP_TRACKER" == linear ]]; then
-    TEAM="$SETUP_TEAM" config_tracker "$dir" linear >/dev/null
-  else
-    TEAM="" config_tracker "$dir" github >/dev/null
-  fi
-  if [[ "$SETUP_SKILLS_CHANGED" -eq 1 ]]; then
-    config_write_conventions "$dir" ${SETUP_LINES[@]+"${SETUP_LINES[@]}"}
-  fi
-  config_show "$dir"
-}
-
-setup_run() {
-  local dir="$1" choice="" tracker_in="" team_in="" line="" confirm="" skill
-  setup_need_tty "$dir"
-  setup_init_ui
-  SETUP_TOTAL=5
-  SETUP_INDEX=0
-  setup_read_existing "$dir"
-
-  setup_stage "Detect"
-  setup_spin "Looking for factory config"
-  if setup_has_existing "$dir"; then
-    printf '  Existing factory config:\n'
-    config_show "$dir" | sed 's/^/  /'
-    printf '\n'
-    while true; do
-      setup_read "Update or keep?" choice "update"
-      case "$(setup_fold "$choice")" in
-        k|keep)
-          printf '\n  Kept existing config.\n'
-          config_show "$dir"
-          return 0
-          ;;
-        u|update) break ;;
-        *) printf '  Type update or keep.\n' ;;
-      esac
-    done
-  else
-    printf '  No factory config yet.\n'
-  fi
-
-  setup_stage "Tracker"
-  printf '  github (default) or linear, which needs a team key.\n'
-  printf '  skip keeps the current tracker.\n\n'
-  while true; do
-    setup_read "Tracker (github, linear, skip)" tracker_in "$SETUP_TRACKER"
-    case "$(setup_fold "$tracker_in")" in
-      s|skip) break ;;
-      github)
-        SETUP_TRACKER="github"
-        SETUP_TEAM=""
-        break
-        ;;
-      linear)
-        while true; do
-          setup_read "Linear team key" team_in "${SETUP_TEAM}"
-          if [[ -n "$team_in" ]]; then
-            SETUP_TRACKER="linear"
-            SETUP_TEAM="$team_in"
-            break
-          fi
-          printf '  Linear needs a team key.\n'
-        done
-        break
-        ;;
-      *) printf '  Choose github, linear, or skip.\n' ;;
-    esac
-  done
-
-  setup_stage "Skills"
-  printf '  Factory skills:\n'
-  for skill in "$FACTORY"/skills/*; do
-    [[ -d "$skill" ]] || continue
-    printf '    %s\n' "${skill##*/}"
-  done
-  printf '\n  One line: "<skill>: <when it applies>" or a convention.\n'
-  printf '  Empty line skips or finishes.\n\n'
-  local collected=()
-  while true; do
-    setup_read "Skill or convention" line
-    [[ -n "$line" ]] || break
-    collected+=("$line")
-  done
-  if (( ${#collected[@]} > 0 )); then
-    SETUP_LINES=("${collected[@]}")
-    SETUP_SKILLS_CHANGED=1
-  fi
-
-  setup_stage "Review"
-  printf '  Tracker: %s\n' "$SETUP_TRACKER"
-  [[ -z "$SETUP_TEAM" ]] || printf '  Team: %s\n' "$SETUP_TEAM"
-  if (( ${#SETUP_LINES[@]} > 0 )); then
-    printf '  Skills:\n'
-    for line in "${SETUP_LINES[@]}"; do
-      printf '    %s\n' "$line"
-    done
-  else
-    printf '  Skills: none\n'
-  fi
-  printf '\n'
-  setup_read "Write this config? [y/N]" confirm
-  case "$(setup_fold "$confirm")" in
-    y|yes) ;;
-    *)
-      printf '\n  Canceled. Nothing written.\n'
-      exit 1
-      ;;
-  esac
-
-  setup_stage "Write"
-  setup_write "$dir"
-  printf '\n  %sWrote factory config.%s\n' "$SETUP_GREEN" "$SETUP_RESET"
 }
 
 conventions_rules() {
@@ -1356,6 +1118,7 @@ case "$LANE" in
     ;;
   setup)
     DIR="$(config_dir)"
+    source "$FACTORY/lib/setup.sh"
     setup_run "$DIR"
     exit $?
     ;;

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ if [[ -n "$WORKSPACE" && -d "$WORKSPACE" ]]; then
 fi
 
 echo
-echo "Next: cd into the product repo, run factory setup, then /lead"
+echo "Next: cd into the product repo, run factory setup, then open grok (or claude) and /lead"
 echo "Owner and repo come from git remote. Workspace is that directory."
 case ":${PATH}:" in
   *":${HOME}/.local/bin:"*) ;;

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ if [[ -n "$WORKSPACE" && -d "$WORKSPACE" ]]; then
 fi
 
 echo
-echo "Next: cd into the product repo, open grok (or claude), /lead"
+echo "Next: cd into the product repo, run factory setup, then /lead"
 echo "Owner and repo come from git remote. Workspace is that directory."
 case ":${PATH}:" in
   *":${HOME}/.local/bin:"*) ;;

--- a/lib/setup.sh
+++ b/lib/setup.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+
+SETUP_TOTAL=4
+SETUP_INDEX=0
+SETUP_COLOR=0
+SETUP_ANIM=0
+SETUP_BOLD=""
+SETUP_DIM=""
+SETUP_RESET=""
+SETUP_CYAN=""
+SETUP_GREEN=""
+SETUP_YELLOW=""
+SETUP_TRACKER="github"
+SETUP_TEAM=""
+SETUP_LINES=()
+SETUP_SKILLS_CHANGED=0
+SETUP_SPIN_PID=""
+
+setup_init_ui() {
+  SETUP_COLOR=0
+  SETUP_ANIM=0
+  SETUP_BOLD=""
+  SETUP_DIM=""
+  SETUP_RESET=""
+  SETUP_CYAN=""
+  SETUP_GREEN=""
+  SETUP_YELLOW=""
+  SETUP_SPIN_PID=""
+  [[ -z "${NO_COLOR:-}" && "${TERM:-dumb}" != "dumb" && -t 1 ]] || return 0
+  command -v tput >/dev/null 2>&1 || return 0
+  local colors
+  colors="$(tput colors 2>/dev/null || echo 0)"
+  [[ "$colors" -ge 8 ]] || return 0
+  SETUP_COLOR=1
+  SETUP_ANIM=1
+  SETUP_BOLD="$(tput bold 2>/dev/null || true)"
+  SETUP_DIM="$(tput dim 2>/dev/null || true)"
+  SETUP_RESET="$(tput sgr0 2>/dev/null || true)"
+  SETUP_CYAN="$(tput setaf 6 2>/dev/null || true)"
+  SETUP_GREEN="$(tput setaf 2 2>/dev/null || true)"
+  SETUP_YELLOW="$(tput setaf 3 2>/dev/null || true)"
+}
+
+setup_need_tty() {
+  local dir="$1"
+  if [[ -t 0 && -t 1 ]]; then
+    return 0
+  fi
+  echo "factory setup needs a terminal. Use factory.sh config for scripts." >&2
+  config_show "$dir" >&2
+  exit 1
+}
+
+setup_clear() {
+  [[ -t 1 && "${TERM:-dumb}" != "dumb" ]] || return 0
+  if command -v tput >/dev/null 2>&1; then
+    tput clear 2>/dev/null || printf '\033[2J\033[H'
+  else
+    printf '\033[2J\033[H'
+  fi
+}
+
+setup_transition() {
+  [[ "$SETUP_ANIM" -eq 1 ]] || return 0
+  local i
+  for i in 1 2 3; do
+    printf '\r  %s·  %s' "$SETUP_DIM" "$SETUP_RESET"
+    sleep 0.04
+    printf '\r  %s·· %s' "$SETUP_DIM" "$SETUP_RESET"
+    sleep 0.04
+    printf '\r  %s···%s' "$SETUP_DIM" "$SETUP_RESET"
+    sleep 0.04
+    printf '\r     \r'
+  done
+}
+
+setup_stage() {
+  local name="$1"
+  setup_transition
+  setup_clear
+  SETUP_INDEX=$((SETUP_INDEX + 1))
+  printf '\n%s%s▸ %s/%s  %s%s\n\n' "$SETUP_BOLD" "$SETUP_CYAN" "$SETUP_INDEX" "$SETUP_TOTAL" "$name" "$SETUP_RESET"
+}
+
+setup_spin_stop() {
+  if [[ -n "${SETUP_SPIN_PID:-}" ]]; then
+    kill "$SETUP_SPIN_PID" 2>/dev/null || true
+    wait "$SETUP_SPIN_PID" 2>/dev/null || true
+    SETUP_SPIN_PID=""
+    printf '\r\033[K'
+  fi
+}
+
+setup_spin() {
+  local msg="$1"
+  setup_spin_stop
+  if [[ "$SETUP_ANIM" -ne 1 ]]; then
+    printf '  %s\n' "$msg"
+    return 0
+  fi
+  (
+    local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏') i=0
+    while :; do
+      printf '\r  %s%s%s %s' "$SETUP_CYAN" "${frames[i]}" "$SETUP_RESET" "$msg"
+      sleep 0.04
+      i=$(( (i + 1) % ${#frames[@]} ))
+    done
+  ) &
+  SETUP_SPIN_PID=$!
+}
+
+setup_read() {
+  local prompt="$1" varname="$2" default="${3:-}" input=""
+  if [[ -n "$default" ]]; then
+    printf '  %s%s%s [%s]: ' "$SETUP_BOLD" "$prompt" "$SETUP_RESET" "$default"
+  else
+    printf '  %s%s%s: ' "$SETUP_BOLD" "$prompt" "$SETUP_RESET"
+  fi
+  if ! IFS= read -r input; then
+    echo "factory setup needs a terminal." >&2
+    exit 1
+  fi
+  input="${input%$'\r'}"
+  input="${input#"${input%%[![:space:]]*}"}"
+  input="${input%"${input##*[![:space:]]}"}"
+  if [[ -z "$input" && -n "$default" ]]; then
+    input="$default"
+  fi
+  printf -v "$varname" '%s' "$input"
+}
+
+setup_read_existing() {
+  local dir="$1"
+  config_read "$dir"
+  SETUP_TRACKER="$CONFIG_TRACKER"
+  SETUP_TEAM="$CONFIG_TEAM"
+  SETUP_LINES=()
+  SETUP_SKILLS_CHANGED=0
+  if (( ${#CONFIG_LINES[@]} > 0 )); then
+    SETUP_LINES=("${CONFIG_LINES[@]}")
+  fi
+}
+
+setup_has_existing() {
+  [[ "${CONFIG_EXISTS:-0}" -eq 1 ]]
+}
+
+setup_fold() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+setup_write() {
+  local dir="$1"
+  if [[ "$SETUP_TRACKER" == linear ]]; then
+    TEAM="$SETUP_TEAM" config_tracker "$dir" linear >/dev/null
+  else
+    TEAM="" config_tracker "$dir" github >/dev/null
+  fi
+  if [[ "$SETUP_SKILLS_CHANGED" -eq 1 ]]; then
+    config_write_conventions "$dir" ${SETUP_LINES[@]+"${SETUP_LINES[@]}"}
+  fi
+  config_show "$dir"
+}
+
+setup_run() {
+  local dir="$1" choice="" tracker_in="" team_in="" line="" confirm="" skill
+  setup_need_tty "$dir"
+  setup_init_ui
+  SETUP_TOTAL=4
+  SETUP_INDEX=0
+
+  setup_stage "Detect"
+  setup_spin "Looking for factory config"
+  setup_read_existing "$dir"
+  setup_spin_stop
+  if setup_has_existing; then
+    printf '  Existing factory config:\n'
+    config_show "$dir" | sed 's/^/  /'
+    printf '\n'
+    while true; do
+      setup_read "Update or keep?" choice "update"
+      case "$(setup_fold "$choice")" in
+        k|keep)
+          printf '\n  Kept existing config.\n'
+          config_show "$dir"
+          return 0
+          ;;
+        u|update) break ;;
+        *) printf '  Type update or keep.\n' ;;
+      esac
+    done
+  else
+    printf '  No factory config yet.\n'
+  fi
+
+  setup_stage "Tracker"
+  printf '  github (default) or linear, which needs a team key.\n'
+  printf '  skip keeps the current tracker.\n\n'
+  while true; do
+    setup_read "Tracker (github, linear, skip)" tracker_in "$SETUP_TRACKER"
+    case "$(setup_fold "$tracker_in")" in
+      s|skip) break ;;
+      github)
+        SETUP_TRACKER="github"
+        SETUP_TEAM=""
+        break
+        ;;
+      linear)
+        while true; do
+          setup_read "Linear team key" team_in "${SETUP_TEAM}"
+          if [[ -n "$team_in" ]]; then
+            SETUP_TRACKER="linear"
+            SETUP_TEAM="$team_in"
+            break
+          fi
+          printf '  Linear needs a team key.\n'
+        done
+        break
+        ;;
+      *) printf '  Choose github, linear, or skip.\n' ;;
+    esac
+  done
+
+  setup_stage "Skills"
+  printf '  Factory skills:\n'
+  for skill in "$FACTORY"/skills/*; do
+    [[ -d "$skill" ]] || continue
+    printf '    %s\n' "${skill##*/}"
+  done
+  printf '\n  One line: "<skill>: <when it applies>" or a convention.\n'
+  if (( ${#SETUP_LINES[@]} > 0 )); then
+    printf '  Current:\n'
+    for line in "${SETUP_LINES[@]}"; do
+      printf '    %s\n' "$line"
+    done
+    printf '  Empty line keeps these. Typed lines replace the list.\n\n'
+  else
+    printf '  Empty line skips or finishes.\n\n'
+  fi
+  local collected=()
+  while true; do
+    setup_read "Skill or convention" line
+    [[ -n "$line" ]] || break
+    collected+=("$line")
+  done
+  if (( ${#collected[@]} > 0 )); then
+    SETUP_LINES=("${collected[@]}")
+    SETUP_SKILLS_CHANGED=1
+  fi
+
+  setup_stage "Review"
+  printf '  Tracker: %s\n' "$SETUP_TRACKER"
+  [[ -z "$SETUP_TEAM" ]] || printf '  Team: %s\n' "$SETUP_TEAM"
+  if (( ${#SETUP_LINES[@]} > 0 )); then
+    printf '  Skills:\n'
+    for line in "${SETUP_LINES[@]}"; do
+      printf '    %s\n' "$line"
+    done
+  else
+    printf '  Skills: none\n'
+  fi
+  printf '\n'
+  setup_read "Write this config? [y/N]" confirm
+  case "$(setup_fold "$confirm")" in
+    y|yes) ;;
+    *)
+      printf '\n  Canceled. Nothing written.\n'
+      exit 1
+      ;;
+  esac
+
+  setup_write "$dir"
+  printf '\n  %sWrote factory config.%s\n' "$SETUP_GREEN" "$SETUP_RESET"
+}

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+unset FACTORY_SKIP_TICKET_COMMENT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
+command -v python3 >/dev/null 2>&1 || fail "python3 required for setup TTY tests"
+
+run_notty() {
+  local code=0
+  set +e
+  (cd "$WS/widgets" && FACTORY_WORKSPACE="$WS" NO_COLOR=1 TERM=dumb "$FACTORY" setup "$@") \
+    </dev/null >"$TMP/out" 2>"$TMP/err"
+  code=$?
+  set -e
+  return "$code"
+}
+
+pty_setup() {
+  local answers="$1" cwd="$2"
+  shift 2
+  NO_COLOR=1 TERM=xterm-256color FACTORY_WORKSPACE="$WS" python3 - "$FACTORY" "$answers" "$cwd" "$@" << 'PY'
+import fcntl, os, pty, signal, struct, sys, termios, time
+
+factory, answers_path, cwd, *rest = sys.argv[1:]
+answers = open(answers_path, "rb").read()
+if answers and not answers.endswith(b"\n"):
+    answers += b"\n"
+winsize = struct.pack("HHHH", 24, 80, 0, 0)
+
+def on_alarm(signum, frame):
+    raise TimeoutError("setup PTY timed out")
+
+signal.signal(signal.SIGALRM, on_alarm)
+signal.alarm(12)
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.chdir(cwd)
+    fcntl.ioctl(1, termios.TIOCSWINSZ, winsize)
+    os.execve(factory, [factory, "setup", *rest], os.environ)
+
+fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)
+time.sleep(0.2)
+os.write(fd, answers)
+
+try:
+    while True:
+        try:
+            data = os.read(fd, 4096)
+        except OSError:
+            break
+        if not data:
+            break
+        sys.stdout.buffer.write(data)
+        sys.stdout.buffer.flush()
+finally:
+    signal.alarm(0)
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+status = None
+try:
+    wpid, status = os.waitpid(pid, os.WNOHANG)
+    if wpid == 0:
+        os.kill(pid, signal.SIGTERM)
+        _, status = os.waitpid(pid, 0)
+except OSError:
+    sys.exit(99)
+if status is None:
+    sys.exit(99)
+
+code = os.waitstatus_to_exitcode(status) if hasattr(os, "waitstatus_to_exitcode") else (
+    os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1
+)
+sys.exit(code)
+PY
+}
+
+answers_file() {
+  printf '%s' "$1" >"$TMP/answers"
+}
+
+# No TTY: do not hang, do not write, mention a terminal
+run_notty && fail "setup without a TTY must fail"
+grep -qi "terminal" "$TMP/err" "$TMP/out" || fail "no-TTY should mention a terminal, got out=$(cat "$TMP/out") err=$(cat "$TMP/err")"
+[[ ! -e "$WS/widgets/.factory/config" ]] || fail "no-TTY must not write .factory/config"
+[[ ! -e "$WS/widgets/.factory/conventions" ]] || fail "no-TTY must not write conventions"
+
+# Piped stdin is still not a TTY and must not write
+set +e
+printf 'u\ngithub\n\ny\n' | (cd "$WS/widgets" && FACTORY_WORKSPACE="$WS" "$FACTORY" setup) >"$TMP/pipe-out" 2>"$TMP/pipe-err"
+pipe_code=$?
+set -e
+[[ "$pipe_code" -ne 0 ]] || fail "piped setup must fail"
+[[ ! -e "$WS/widgets/.factory/config" ]] || fail "piped setup must not write config"
+
+# --yes is for workers, not the wizard
+set +e
+(cd "$WS/widgets" && FACTORY_WORKSPACE="$WS" "$FACTORY" setup --yes) >"$TMP/yes-out" 2>"$TMP/yes-err"
+yes_code=$?
+set -e
+[[ "$yes_code" -ne 0 ]] || fail "setup --yes must fail"
+grep -qi "config" "$TMP/yes-err" "$TMP/yes-out" || fail "setup --yes should point at factory.sh config, got $(cat "$TMP/yes-err")$(cat "$TMP/yes-out")"
+[[ ! -e "$WS/widgets/.factory/config" ]] || fail "setup --yes must not write"
+
+# Detect existing config and keep it
+mkdir -p "$WS/widgets/.factory"
+printf 'tracker=linear\nteam=KEEP\n' >"$WS/widgets/.factory/config"
+printf 'euc-go: Go services\n' >"$WS/widgets/.factory/conventions"
+before_cfg="$(cat "$WS/widgets/.factory/config")"
+before_conv="$(cat "$WS/widgets/.factory/conventions")"
+answers_file $'k\n'
+set +e
+pty_setup "$TMP/answers" "$WS/widgets" >"$TMP/keep-out" 2>"$TMP/keep-err"
+keep_code=$?
+set -e
+[[ "$keep_code" -eq 0 ]] || fail "keep should exit 0, err=$(cat "$TMP/keep-err") out=$(cat "$TMP/keep-out")"
+grep -qi "existing" "$TMP/keep-out" || fail "detect should mention existing config, got $(cat "$TMP/keep-out")"
+grep -qi "keep" "$TMP/keep-out" || fail "detect should offer keep, got $(cat "$TMP/keep-out")"
+[[ "$(cat "$WS/widgets/.factory/config")" == "$before_cfg" ]] || fail "keep must not change config"
+[[ "$(cat "$WS/widgets/.factory/conventions")" == "$before_conv" ]] || fail "keep must not change conventions"
+
+# Cancel at review leaves files unchanged
+answers_file $'u\nskip\n\nn\n'
+set +e
+pty_setup "$TMP/answers" "$WS/widgets" >"$TMP/cancel-out" 2>"$TMP/cancel-err"
+cancel_code=$?
+set -e
+[[ "$cancel_code" -ne 0 ]] || fail "cancel should be a non-zero exit"
+[[ "$(cat "$WS/widgets/.factory/config")" == "$before_cfg" ]] || fail "cancel must not change config"
+[[ "$(cat "$WS/widgets/.factory/conventions")" == "$before_conv" ]] || fail "cancel must not change conventions"
+grep -qi "review" "$TMP/cancel-out" || fail "cancel path should reach review, got $(cat "$TMP/cancel-out")"
+
+# Skip optional sections, write github default through config writers
+rm -rf "$WS/widgets/.factory"
+answers_file $'skip\n\ny\n'
+set +e
+pty_setup "$TMP/answers" "$WS/widgets" >"$TMP/skip-out" 2>"$TMP/skip-err"
+skip_code=$?
+set -e
+[[ "$skip_code" -eq 0 ]] || fail "skip+confirm should succeed, err=$(cat "$TMP/skip-err") out=$(cat "$TMP/skip-out")"
+[[ -f "$WS/widgets/.factory/config" ]] || fail "skip+confirm should write tracker via config"
+grep -qxF "tracker=github" "$WS/widgets/.factory/config" || fail "skip tracker should land github default, got $(cat "$WS/widgets/.factory/config")"
+[[ ! -e "$WS/widgets/.factory/conventions" ]] || fail "skip skills should not write conventions"
+grep -qxF ".factory/" "$WS/widgets/.git/info/exclude" || fail "setup write should exclude .factory/"
+grep -q $'⠋' "$TMP/skip-out" && fail "NO_COLOR must not animate a spinner"
+
+# Write-through-config: tracker linear + skill and convention lines in the #35 format
+rm -rf "$WS/widgets/.factory"
+answers_file $'linear\nABC\ntdd: features and bug fixes\nnever add jest tests\n\ny\n'
+set +e
+pty_setup "$TMP/answers" "$WS/widgets" >"$TMP/write-out" 2>"$TMP/write-err"
+write_code=$?
+set -e
+[[ "$write_code" -eq 0 ]] || fail "write should succeed, err=$(cat "$TMP/write-err") out=$(cat "$TMP/write-out")"
+grep -qxF "tracker=linear" "$WS/widgets/.factory/config" || fail "linear tracker missing, got $(cat "$WS/widgets/.factory/config")"
+grep -qxF "team=ABC" "$WS/widgets/.factory/config" || fail "linear team missing, got $(cat "$WS/widgets/.factory/config")"
+grep -qxF "tdd: features and bug fixes" "$WS/widgets/.factory/conventions" || fail "skill line missing, got $(cat "$WS/widgets/.factory/conventions")"
+grep -qxF "never add jest tests" "$WS/widgets/.factory/conventions" || fail "convention line missing, got $(cat "$WS/widgets/.factory/conventions")"
+out="$(FACTORY_WORKSPACE="$WS" "$FACTORY" config --repo widgets)"
+grep -q "tracker linear" <<< "$out" || fail "config should show what setup wrote, got: $out"
+grep -q "tdd: features and bug fixes" <<< "$out" || fail "config should list the skill setup wrote, got: $out"
+awk '
+  /^setup_write\(\)/ {on=1}
+  on {print}
+  on && /^}$/ {exit}
+' "$FACTORY" | grep -q "config_tracker" || fail "setup_write must call config_tracker"
+awk '
+  /^setup_write\(\)/ {on=1}
+  on {print}
+  on && /^}$/ {exit}
+' "$FACTORY" | grep -q "config_write_conventions" || fail "setup_write must call config_write_conventions"
+
+# Existing config, update tracker, skip skills (leave conventions)
+printf 'tracker=github\n' >"$WS/widgets/.factory/config"
+printf 'euc-go: Go services\n' >"$WS/widgets/.factory/conventions"
+answers_file $'u\nlinear\nZZZ\n\ny\n'
+set +e
+pty_setup "$TMP/answers" "$WS/widgets" >"$TMP/upd-out" 2>"$TMP/upd-err"
+upd_code=$?
+set -e
+[[ "$upd_code" -eq 0 ]] || fail "update should succeed, err=$(cat "$TMP/upd-err") out=$(cat "$TMP/upd-out")"
+grep -qxF "tracker=linear" "$WS/widgets/.factory/config" || fail "update should change tracker"
+grep -qxF "euc-go: Go services" "$WS/widgets/.factory/conventions" || fail "skip skills should keep existing conventions"
+
+# --repo still targets the named checkout
+mkdir -p "$WS/other"
+git -C "$WS/other" init -q
+git -C "$WS/other" remote add origin "https://github.com/acme/other.git"
+rm -rf "$WS/widgets/.factory"
+answers_file $'skip\n\ny\n'
+set +e
+pty_setup "$TMP/answers" "$WS/other" --repo widgets >"$TMP/repo-out" 2>"$TMP/repo-err"
+repo_code=$?
+set -e
+[[ "$repo_code" -eq 0 ]] || fail "--repo setup failed, err=$(cat "$TMP/repo-err") out=$(cat "$TMP/repo-out")"
+[[ ! -e "$WS/other/.factory/config" ]] || fail "setup --repo widgets must not write the cwd checkout"
+grep -qxF "tracker=github" "$WS/widgets/.factory/config" || fail "setup --repo widgets must write widgets"
+
+# README documents factory setup; install.sh is still the plugin install
+grep -q "factory setup" "$ROOT/README.md" || fail "README missing factory setup"
+grep -q "factory.sh config" "$ROOT/README.md" || fail "README should still document factory.sh config"
+if grep -E '\$FACTORY setup|factory\.sh setup' "$ROOT/install.sh"; then
+  fail "install.sh must not run the setup wizard"
+fi
+grep -q "factory setup" "$ROOT/install.sh" || fail "install.sh should point at factory setup after plugin install"
+grep -q "factory.sh setup" "$FACTORY" || fail "usage should list factory.sh setup"
+
+# install.sh <checkout> still does not write factory config
+hid="$TMP/bin"
+mkdir -p "$hid"
+for cmd in bash mkdir ln rm echo grep command cat cp dirname pwd; do
+  src="$(command -v "$cmd" || true)"
+  [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
+done
+prod="$TMP/product"
+mkdir -p "$prod"
+HOME="$TMP/home" PATH="$hid" "$ROOT/install.sh" "$prod" >/dev/null
+[[ ! -e "$prod/.factory/config" ]] || fail "install.sh must not write .factory/config"
+[[ ! -e "$prod/.factory/conventions" ]] || fail "install.sh must not write conventions"
+
+echo "ok setup"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -175,16 +175,35 @@ grep -qxF "never add jest tests" "$WS/widgets/.factory/conventions" || fail "con
 out="$(FACTORY_WORKSPACE="$WS" "$FACTORY" config --repo widgets)"
 grep -q "tracker linear" <<< "$out" || fail "config should show what setup wrote, got: $out"
 grep -q "tdd: features and bug fixes" <<< "$out" || fail "config should list the skill setup wrote, got: $out"
+SETUP_LIB="$ROOT/lib/setup.sh"
+[[ -f "$SETUP_LIB" ]] || fail "TTY wizard must live in lib/setup.sh"
+grep -q 'lib/setup.sh' "$FACTORY" || fail "factory.sh must source lib/setup.sh"
+if grep -q '^setup_run()' "$FACTORY"; then
+  fail "setup_run must not be defined in factory.sh"
+fi
+if grep -q '^setup_init_ui()' "$FACTORY"; then
+  fail "TTY paint must not live in factory.sh"
+fi
 awk '
   /^setup_write\(\)/ {on=1}
   on {print}
   on && /^}$/ {exit}
-' "$FACTORY" | grep -q "config_tracker" || fail "setup_write must call config_tracker"
+' "$SETUP_LIB" | grep -q "config_tracker" || fail "setup_write must call config_tracker"
 awk '
   /^setup_write\(\)/ {on=1}
   on {print}
   on && /^}$/ {exit}
-' "$FACTORY" | grep -q "config_write_conventions" || fail "setup_write must call config_write_conventions"
+' "$SETUP_LIB" | grep -q "config_write_conventions" || fail "setup_write must call config_write_conventions"
+awk '
+  /^config_show\(\)/ {on=1}
+  on {print}
+  on && /^}$/ {exit}
+' "$FACTORY" | grep -q "config_read" || fail "config_show must use config_read"
+grep -q 'config_read' "$SETUP_LIB" || fail "wizard must read existing config through config_read"
+
+# Confirm writes in place; write is not another numbered stage
+grep -E '5/5[[:space:]]+Write' "$TMP/skip-out" && fail "write must not be its own stage, got $(cat "$TMP/skip-out")"
+grep -qi "wrote factory config" "$TMP/skip-out" || fail "confirm should write on the review screen, got $(cat "$TMP/skip-out")"
 
 # Existing config, update tracker, skip skills (leave conventions)
 printf 'tracker=github\n' >"$WS/widgets/.factory/config"
@@ -197,6 +216,21 @@ set -e
 [[ "$upd_code" -eq 0 ]] || fail "update should succeed, err=$(cat "$TMP/upd-err") out=$(cat "$TMP/upd-out")"
 grep -qxF "tracker=linear" "$WS/widgets/.factory/config" || fail "update should change tracker"
 grep -qxF "euc-go: Go services" "$WS/widgets/.factory/conventions" || fail "skip skills should keep existing conventions"
+grep -qi "current" "$TMP/upd-out" || fail "skills stage should show existing lines, got $(cat "$TMP/upd-out")"
+grep -q "euc-go: Go services" "$TMP/upd-out" || fail "skills stage should list current conventions, got $(cat "$TMP/upd-out")"
+
+# Typed skill lines replace the list after showing current
+printf 'tracker=github\n' >"$WS/widgets/.factory/config"
+printf 'euc-go: Go services\n' >"$WS/widgets/.factory/conventions"
+answers_file $'u\nskip\ntdd: features and bug fixes\n\ny\n'
+set +e
+pty_setup "$TMP/answers" "$WS/widgets" >"$TMP/repl-out" 2>"$TMP/repl-err"
+repl_code=$?
+set -e
+[[ "$repl_code" -eq 0 ]] || fail "replace skills should succeed, err=$(cat "$TMP/repl-err") out=$(cat "$TMP/repl-out")"
+grep -qi "current" "$TMP/repl-out" || fail "replace path should show existing lines first, got $(cat "$TMP/repl-out")"
+grep -qxF "tdd: features and bug fixes" "$WS/widgets/.factory/conventions" || fail "typed skills should replace conventions"
+grep -q "euc-go" "$WS/widgets/.factory/conventions" && fail "typed skills must not keep old conventions"
 
 # --repo still targets the named checkout
 mkdir -p "$WS/other"
@@ -219,6 +253,7 @@ if grep -E '\$FACTORY setup|factory\.sh setup' "$ROOT/install.sh"; then
   fail "install.sh must not run the setup wizard"
 fi
 grep -q "factory setup" "$ROOT/install.sh" || fail "install.sh should point at factory setup after plugin install"
+grep -Eq 'Next:.*factory setup.*(grok|claude)' "$ROOT/install.sh" || fail "install next step should keep the runner after factory setup"
 grep -q "factory.sh setup" "$FACTORY" || fail "usage should list factory.sh setup"
 
 # install.sh <checkout> still does not write factory config
@@ -233,5 +268,18 @@ mkdir -p "$prod"
 HOME="$TMP/home" PATH="$hid" "$ROOT/install.sh" "$prod" >/dev/null
 [[ ! -e "$prod/.factory/config" ]] || fail "install.sh must not write .factory/config"
 [[ ! -e "$prod/.factory/conventions" ]] || fail "install.sh must not write conventions"
+
+# The PATH command from install.sh is a symlink at ~/.local/bin/factory
+factory_cli="$TMP/home/.local/bin/factory"
+[[ -L "$factory_cli" ]] || fail "install should leave a factory symlink"
+rm -rf "$WS/widgets/.factory"
+set +e
+(cd "$WS/widgets" && PATH="$(dirname "$factory_cli"):$PATH" FACTORY_WORKSPACE="$WS" NO_COLOR=1 TERM=dumb factory setup) \
+  </dev/null >"$TMP/sym-out" 2>"$TMP/sym-err"
+sym_code=$?
+set -e
+[[ "$sym_code" -ne 0 ]] || fail "factory setup via the install symlink without a TTY must fail"
+grep -qi "terminal" "$TMP/sym-err" "$TMP/sym-out" || fail "symlink factory setup should mention a terminal, got out=$(cat "$TMP/sym-out") err=$(cat "$TMP/sym-err")"
+[[ ! -e "$WS/widgets/.factory/config" ]] || fail "symlink factory setup without a TTY must not write"
 
 echo "ok setup"


### PR DESCRIPTION
`factory setup` is the human path over the existing `factory.sh config` writers: detect, tracker, skills, review, then write. No TTY prints current config and exits; cancel and keep leave files unchanged. Pattern matches PR 46 (`factory.sh config`).

Implements #49.