### PR TITLE
Feat/47/issue tracking as an MCP plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The runner is a plug. Grok, Claude Code, Codex, Cursor. Same `AGENTS.md`, same s
 
 Telemetry is a plug too. Not an error inbox. It answers whether a path broke or a feature died: signup, onboarding, checkout, invite, the core loop, a shipped screen nobody finishes. PostHog, Datadog, Azure App Insights, and CloudWatch all speak [`telemetry/CONTRACT.md`](telemetry/CONTRACT.md). Swap the vendor. Keep the questions.
 
+Issue tracking is a plug. GitHub is the default. Linear and Jira are names in `.factory/config`, not adapters in this repo. Point `FACTORY_TRACKER_CMD` at an MCP command that can `get` a ticket and `comment` on it. See [`tracker/CONTRACT.md`](tracker/CONTRACT.md). PRs, reviews, checks, and close-linked stay on GitHub.
+
 ![Software factory](docs/factory.png)
 
 
@@ -29,7 +31,7 @@ Two ledgers. Keep them apart.
 
 **Local.** `factory.sh mem write` and `mem read` hit `~/.factory/memory/factory.db`. The next `/bug` or `factory.sh feature` reads those rows at start. A worker writes `started` only if nothing is in progress, then `done`, `blocked`, or `failed`. If the db is missing, warn once and continue. Optional. Best-effort. Not git. Never `.env`.
 
-**GitHub.** On `done`, `blocked`, or `failed` (not `started`), the write leaves one GitHub comment. The body is the one-sentence summary. When a PR exists, a blank line, then a markdown link `[PR n](url)`. That comment is the public ledger. Tech lead reads GitHub when local memory has no rows. Memory is a hint, not a lock.
+**GitHub.** On `done`, `blocked`, or `failed` (not `started`), the write leaves one comment on the ticket. GitHub is the default. `FACTORY_TRACKER_CMD` sends that comment through the tracker plug instead. The body is the one-sentence summary. When a PR exists, a blank line, then a markdown link `[PR n](url)`. That comment is the public ledger. Tech lead reads GitHub when local memory has no rows. Memory is a hint, not a lock.
 
 Floor asks GitHub whether there is a PR, a review, and green checks. It asks local memory for `blocked` / `failed` and for "QA was skipped, no URL."
 
@@ -146,7 +148,7 @@ Headless. Never merges.
 ./factory.sh config
 ```
 
-`factory.sh config` sets a checkout up for the factory without hand-editing files. `config tracker github|linear [--team <linear-team-key>]` stores the issue tracker in `.factory/config`; github is the default when no config exists, and linear requires a team key. `config skills "<skill-name>: <when it applies>" [more...]` replaces `.factory/conventions` with those entries, one per line. `config` with no arguments prints the current tracker and skills. It targets `--repo <name>` under the workspace, or the checkout you run it from. Both files live under `.factory/`, which factory.sh adds to the checkout's `.git/info/exclude` so they stay out of source control.
+`factory.sh config` sets a checkout up for the factory without hand-editing files. `config tracker github|linear [--team <linear-team-key>]` stores the issue tracker in `.factory/config`; github is the default when no config exists, and linear requires a team key. That name is not an adapter. Add the GitHub, Linear, or Jira MCP connector to the harness, then set `FACTORY_TRACKER_CMD` to a command that speaks [`tracker/CONTRACT.md`](tracker/CONTRACT.md). `get <id>` prints the ticket. `comment <id> --body <text>` posts on it. The factory loads id, title, body, labels, url, and status and hands them to the lane. Lanes do not call GitHub issue APIs for ticket context. `config skills "<skill-name>: <when it applies>" [more...]` replaces `.factory/conventions` with those entries, one per line. `config` with no arguments prints the current tracker and skills. It targets `--repo <name>` under the workspace, or the checkout you run it from. Both files live under `.factory/`, which factory.sh adds to the checkout's `.git/info/exclude` so they stay out of source control.
 
 `factory.sh ship` is an alias of `floor`. QA URL is `--url` or `FACTORY_QA_URL`. `--yes` is for workers. Lead stays interactive for quiz and for `blocked`.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The runner is a plug. Grok, Claude Code, Codex, Cursor. Same `AGENTS.md`, same s
 
 Telemetry is a plug too. Not an error inbox. It answers whether a path broke or a feature died: signup, onboarding, checkout, invite, the core loop, a shipped screen nobody finishes. PostHog, Datadog, Azure App Insights, and CloudWatch all speak [`telemetry/CONTRACT.md`](telemetry/CONTRACT.md). Swap the vendor. Keep the questions.
 
-Issue tracking is a plug. GitHub is the default. Linear and Jira are names in `.factory/config`, not adapters in this repo. Point `FACTORY_TRACKER_CMD` at an MCP command that can `get` a ticket and `comment` on it. See [`tracker/CONTRACT.md`](tracker/CONTRACT.md). PRs, reviews, checks, and close-linked stay on GitHub.
+Issue tracking is a plug. GitHub is the default. `factory.sh config tracker github|linear` writes a name to `.factory/config`. Point `FACTORY_TRACKER_CMD` at an MCP command that can `get` a ticket and `comment` on it, including a Linear or Jira connector. See [`tracker/CONTRACT.md`](tracker/CONTRACT.md). PRs, reviews, checks, and close-linked stay on GitHub.
 
 ![Software factory](docs/factory.png)
 

--- a/factory.sh
+++ b/factory.sh
@@ -835,7 +835,7 @@ run_mem_lane() {
 
 floor_classify() {
   local name
-  ticket_get || true
+  ticket_get || return 1
   [[ -n "${TICKET_LABELS:-}" ]] || { printf '%s\n' feature; return 0; }
   while IFS= read -r name; do
     name="${name#"${name%%[![:space:]]*}"}"
@@ -938,7 +938,7 @@ floor_next() {
       failed) printf '%s\n' stop:failed; return 0 ;;
     esac
   done
-  impl="$(floor_classify)"
+  impl="$(floor_classify)" || return 1
   if [[ "$impl" == bug ]]; then
     s="$(printf '%s\n' "$raw" | latest_lane_status telemetry)"
     if [[ -z "$s" && -z "${FLOOR_DID_TEL:-}" ]]; then
@@ -996,7 +996,7 @@ floor_run() {
     pr="$(floor_pr_from_mem)"
     [[ -n "$pr" ]] || pr="$(floor_pr_from_gh)"
     [[ -n "$pr" ]] && PR="$pr"
-    next="$(floor_next)"
+    next="$(floor_next)" || return 1
     case "$next" in
       stop:blocked)
         echo "blocked. stop."
@@ -1079,7 +1079,8 @@ case "$LANE" in
     RULES="$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD"
     CONVENTIONS="$(conventions_rules "$DIR")"
     [[ -z "$CONVENTIONS" ]] || RULES+=$'\n'"$CONVENTIONS"
-    run_mem_lane "$LANE" "$DIR" "$RULES" "Implement this ticket in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."$'\n\n'"$(ticket_context)"
+    ctx="$(ticket_context)" || exit 1
+    run_mem_lane "$LANE" "$DIR" "$RULES" "Implement this ticket in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."$'\n\n'"$ctx"
     exit $?
     ;;
   review)
@@ -1112,7 +1113,8 @@ case "$LANE" in
     need_issue
     mem_read_context
     prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}. After tickets exist, start factory.sh floor --repo ${REPO:-<repo>} --issue ${ISSUE} (or one factory.sh lane). Dispatch is factory.sh only. Writing product code, leaving a review, or watching CI in this session is a failed run."
-    prompt+=$'\n\n'"$(ticket_context)"
+    ctx="$(ticket_context)" || exit 1
+    prompt+=$'\n\n'"$ctx"
     if [[ -n "${MEM_CONTEXT:-}" ]]; then
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
     fi

--- a/factory.sh
+++ b/factory.sh
@@ -5,6 +5,7 @@ FACTORY="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE="${FACTORY_WORKSPACE:-$PWD}"
 OWNER="${FACTORY_OWNER:-}"
 RUNNER="${FACTORY_RUNNER:-}"
+. "$FACTORY/tracker/tracker.sh"
 
 usage() {
   cat <<EOF
@@ -256,125 +257,6 @@ config_tracker() {
     printf 'tracker=github\n' > "$dir/.factory/config"
   fi
   config_show "$dir"
-}
-
-TRACKER="github"
-TRACKER_TEAM=""
-TRACKER_CMD=""
-TICKET_ID=""
-TICKET_TITLE=""
-TICKET_URL=""
-TICKET_STATUS=""
-TICKET_LABELS=""
-TICKET_BODY=""
-
-load_tracker() {
-  local dir="" line
-  TRACKER="github"
-  TRACKER_TEAM=""
-  TRACKER_CMD="${FACTORY_TRACKER_CMD:-}"
-  if [[ -n "${REPO:-}" && -d "$WORKSPACE/$REPO" ]]; then
-    dir="$(git -C "$WORKSPACE/$REPO" rev-parse --show-toplevel 2>/dev/null || true)"
-  fi
-  if [[ -z "$dir" ]]; then
-    dir="$(git rev-parse --show-toplevel 2>/dev/null || git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || true)"
-  fi
-  [[ -n "$dir" && -f "$dir/.factory/config" ]] || return 0
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    case "$line" in
-      tracker=*) TRACKER="${line#tracker=}" ;;
-      team=*) TRACKER_TEAM="${line#team=}" ;;
-    esac
-  done < "$dir/.factory/config"
-}
-
-parse_ticket_record() {
-  local in_body=0 line unstructured=1
-  TICKET_ID=""
-  TICKET_TITLE=""
-  TICKET_URL=""
-  TICKET_STATUS=""
-  TICKET_LABELS=""
-  TICKET_BODY=""
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    if [[ "$in_body" -eq 1 ]]; then
-      if [[ -n "$TICKET_BODY" ]]; then
-        TICKET_BODY+=$'\n'"$line"
-      else
-        TICKET_BODY="$line"
-      fi
-      continue
-    fi
-    case "$line" in
-      id=*) TICKET_ID="${line#id=}"; unstructured=0 ;;
-      title=*) TICKET_TITLE="${line#title=}"; unstructured=0 ;;
-      url=*) TICKET_URL="${line#url=}"; unstructured=0 ;;
-      status=*) TICKET_STATUS="${line#status=}"; unstructured=0 ;;
-      labels=*)
-        TICKET_LABELS="${line#labels=}"
-        TICKET_LABELS="${TICKET_LABELS%,}"
-        unstructured=0
-        ;;
-      body:*)
-        in_body=1
-        TICKET_BODY="${line#body:}"
-        TICKET_BODY="${TICKET_BODY# }"
-        unstructured=0
-        ;;
-      body=*)
-        in_body=1
-        TICKET_BODY="${line#body=}"
-        unstructured=0
-        ;;
-    esac
-  done <<< "$1"
-  if [[ "$unstructured" -eq 1 ]]; then
-    TICKET_LABELS=""
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      [[ -n "$line" ]] || continue
-      TICKET_LABELS+="${TICKET_LABELS:+,}$line"
-    done <<< "$1"
-  fi
-}
-
-github_ticket_get() {
-  command -v gh >/dev/null 2>&1 || return 1
-  [[ -n "${OWNER:-}" && -n "${REPO:-}" && -n "${ISSUE:-}" ]] || return 1
-  gh issue view "$ISSUE" -R "${OWNER}/${REPO}" --json number,title,body,labels,url,state --template $'id={{.number}}\ntitle={{.title}}\nurl={{.url}}\nstatus={{.state}}\nlabels={{range .labels}}{{.name}},{{end}}\nbody:\n{{.body}}\n' 2>/dev/null
-}
-
-ticket_get() {
-  local raw=""
-  TICKET_ID="${ISSUE:-}"
-  TICKET_TITLE=""
-  TICKET_URL=""
-  TICKET_STATUS=""
-  TICKET_LABELS=""
-  TICKET_BODY=""
-  [[ -n "${ISSUE:-}" ]] || return 1
-  load_tracker
-  if [[ -n "$TRACKER_CMD" ]]; then
-    raw="$("$TRACKER_CMD" get "$ISSUE" 2>/dev/null || true)"
-  elif [[ "$TRACKER" == github ]]; then
-    raw="$(github_ticket_get || true)"
-  else
-    return 0
-  fi
-  [[ -n "$raw" ]] || return 0
-  parse_ticket_record "$raw"
-  [[ -n "$TICKET_ID" ]] || TICKET_ID="$ISSUE"
-}
-
-ticket_context() {
-  ticket_get || true
-  local out=""
-  out="id: ${TICKET_ID:-${ISSUE:-}}"
-  [[ -z "$TICKET_TITLE" ]] || out+=$'\n'"title: $TICKET_TITLE"
-  [[ -z "$TICKET_URL" ]] || out+=$'\n'"url: $TICKET_URL"
-  [[ -z "$TICKET_STATUS" ]] || out+=$'\n'"status: $TICKET_STATUS"
-  [[ -z "$TICKET_LABELS" ]] || out+=$'\n'"labels: $TICKET_LABELS"
-  [[ -z "$TICKET_BODY" ]] || out+=$'\n\n'"$TICKET_BODY"
-  printf '%s\n' "$out"
 }
 
 config_skills() {
@@ -813,20 +695,8 @@ ticket_comment() {
   err="$(mktemp)"
   set +e
   if [[ -n "${ISSUE:-}" ]]; then
-    load_tracker
-    if [[ -n "$TRACKER_CMD" ]]; then
-      "$TRACKER_CMD" comment "$ISSUE" --body "$body" >/dev/null 2>"$err"
-      code=$?
-    elif [[ "$TRACKER" == github ]]; then
-      [[ -n "${OWNER:-}" && -n "${REPO:-}" ]] || { rm -f "$err"; return 0; }
-      command -v gh >/dev/null 2>&1 || { warn_mem "gh not installed"; rm -f "$err"; return 0; }
-      gh issue comment "$ISSUE" -R "${OWNER}/${REPO}" --body "$body" >/dev/null 2>"$err"
-      code=$?
-    else
-      warn_mem "Need FACTORY_TRACKER_CMD to comment on tracker $TRACKER"
-      rm -f "$err"
-      return 0
-    fi
+    ticket_issue_comment "$body" "$err"
+    code=$?
   else
     [[ -n "${OWNER:-}" && -n "${REPO:-}" ]] || { rm -f "$err"; return 0; }
     command -v gh >/dev/null 2>&1 || { warn_mem "gh not installed"; rm -f "$err"; return 0; }
@@ -964,17 +834,17 @@ run_mem_lane() {
 }
 
 floor_classify() {
-  local name labels
+  local name
   ticket_get || true
-  labels="${TICKET_LABELS:-}"
-  [[ -n "$labels" ]] || { printf '%s\n' feature; return 0; }
-  labels="${labels//,/ }"
-  for name in $labels; do
+  [[ -n "${TICKET_LABELS:-}" ]] || { printf '%s\n' feature; return 0; }
+  while IFS= read -r name; do
+    name="${name#"${name%%[![:space:]]*}"}"
+    name="${name%"${name##*[![:space:]]}"}"
     case "$name" in
       bug) printf '%s\n' bug; return 0 ;;
       documentation|docs) printf '%s\n' docs; return 0 ;;
     esac
-  done
+  done <<< "${TICKET_LABELS//,/$'\n'}"
   printf '%s\n' feature
 }
 
@@ -1241,11 +1111,7 @@ case "$LANE" in
   lead|tech-lead|cto)
     need_issue
     mem_read_context
-    load_tracker
-    prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}. After tickets exist, start factory.sh floor --repo ${REPO:-<repo>} --issue ${ISSUE} (or one factory.sh lane). Dispatch is factory.sh only. Writing product code, leaving a review, or watching CI in this session is a failed run. PRs stay on GitHub."
-    if [[ "$TRACKER" != github ]]; then
-      prompt+=$'\n'"Publish new tickets on the configured tracker, not GitHub issues."
-    fi
+    prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}. After tickets exist, start factory.sh floor --repo ${REPO:-<repo>} --issue ${ISSUE} (or one factory.sh lane). Dispatch is factory.sh only. Writing product code, leaving a review, or watching CI in this session is a failed run."
     prompt+=$'\n\n'"$(ticket_context)"
     if [[ -n "${MEM_CONTEXT:-}" ]]; then
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"

--- a/factory.sh
+++ b/factory.sh
@@ -26,6 +26,7 @@ Usage:
 Never merges. A person merges.
 Workspace defaults to this directory. Owner and repo default from git remote origin. FACTORY_RUNNER if more than one of claude, codex, grok is on PATH.
 Memory: FACTORY_MEMORY_DB (default ~/.factory/memory/factory.db). Optional. Missing db warns and continues.
+Issue tracker: GitHub gh is the default. FACTORY_TRACKER_CMD is an MCP command that speaks tracker/CONTRACT.md (get <id>, comment <id> --body).
 EOF
   exit 1
 }
@@ -255,6 +256,125 @@ config_tracker() {
     printf 'tracker=github\n' > "$dir/.factory/config"
   fi
   config_show "$dir"
+}
+
+TRACKER="github"
+TRACKER_TEAM=""
+TRACKER_CMD=""
+TICKET_ID=""
+TICKET_TITLE=""
+TICKET_URL=""
+TICKET_STATUS=""
+TICKET_LABELS=""
+TICKET_BODY=""
+
+load_tracker() {
+  local dir="" line
+  TRACKER="github"
+  TRACKER_TEAM=""
+  TRACKER_CMD="${FACTORY_TRACKER_CMD:-}"
+  if [[ -n "${REPO:-}" && -d "$WORKSPACE/$REPO" ]]; then
+    dir="$(git -C "$WORKSPACE/$REPO" rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  if [[ -z "$dir" ]]; then
+    dir="$(git rev-parse --show-toplevel 2>/dev/null || git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  [[ -n "$dir" && -f "$dir/.factory/config" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      tracker=*) TRACKER="${line#tracker=}" ;;
+      team=*) TRACKER_TEAM="${line#team=}" ;;
+    esac
+  done < "$dir/.factory/config"
+}
+
+parse_ticket_record() {
+  local in_body=0 line unstructured=1
+  TICKET_ID=""
+  TICKET_TITLE=""
+  TICKET_URL=""
+  TICKET_STATUS=""
+  TICKET_LABELS=""
+  TICKET_BODY=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$in_body" -eq 1 ]]; then
+      if [[ -n "$TICKET_BODY" ]]; then
+        TICKET_BODY+=$'\n'"$line"
+      else
+        TICKET_BODY="$line"
+      fi
+      continue
+    fi
+    case "$line" in
+      id=*) TICKET_ID="${line#id=}"; unstructured=0 ;;
+      title=*) TICKET_TITLE="${line#title=}"; unstructured=0 ;;
+      url=*) TICKET_URL="${line#url=}"; unstructured=0 ;;
+      status=*) TICKET_STATUS="${line#status=}"; unstructured=0 ;;
+      labels=*)
+        TICKET_LABELS="${line#labels=}"
+        TICKET_LABELS="${TICKET_LABELS%,}"
+        unstructured=0
+        ;;
+      body:*)
+        in_body=1
+        TICKET_BODY="${line#body:}"
+        TICKET_BODY="${TICKET_BODY# }"
+        unstructured=0
+        ;;
+      body=*)
+        in_body=1
+        TICKET_BODY="${line#body=}"
+        unstructured=0
+        ;;
+    esac
+  done <<< "$1"
+  if [[ "$unstructured" -eq 1 ]]; then
+    TICKET_LABELS=""
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -n "$line" ]] || continue
+      TICKET_LABELS+="${TICKET_LABELS:+,}$line"
+    done <<< "$1"
+  fi
+}
+
+github_ticket_get() {
+  command -v gh >/dev/null 2>&1 || return 1
+  [[ -n "${OWNER:-}" && -n "${REPO:-}" && -n "${ISSUE:-}" ]] || return 1
+  gh issue view "$ISSUE" -R "${OWNER}/${REPO}" --json number,title,body,labels,url,state --template $'id={{.number}}\ntitle={{.title}}\nurl={{.url}}\nstatus={{.state}}\nlabels={{range .labels}}{{.name}},{{end}}\nbody:\n{{.body}}\n' 2>/dev/null
+}
+
+ticket_get() {
+  local raw=""
+  TICKET_ID="${ISSUE:-}"
+  TICKET_TITLE=""
+  TICKET_URL=""
+  TICKET_STATUS=""
+  TICKET_LABELS=""
+  TICKET_BODY=""
+  [[ -n "${ISSUE:-}" ]] || return 1
+  load_tracker
+  if [[ -n "$TRACKER_CMD" ]]; then
+    raw="$("$TRACKER_CMD" get "$ISSUE" 2>/dev/null || true)"
+  elif [[ "$TRACKER" == github ]]; then
+    raw="$(github_ticket_get || true)"
+  else
+    return 0
+  fi
+  [[ -n "$raw" ]] || return 0
+  parse_ticket_record "$raw"
+  [[ -n "$TICKET_ID" ]] || TICKET_ID="$ISSUE"
+}
+
+ticket_context() {
+  ticket_get || true
+  local out=""
+  out="id: ${TICKET_ID:-${ISSUE:-}}"
+  [[ -z "$TICKET_TITLE" ]] || out+=$'\n'"title: $TICKET_TITLE"
+  [[ -z "$TICKET_URL" ]] || out+=$'\n'"url: $TICKET_URL"
+  [[ -z "$TICKET_STATUS" ]] || out+=$'\n'"status: $TICKET_STATUS"
+  [[ -z "$TICKET_LABELS" ]] || out+=$'\n'"labels: $TICKET_LABELS"
+  [[ -z "$TICKET_BODY" ]] || out+=$'\n\n'"$TICKET_BODY"
+  printf '%s\n' "$out"
 }
 
 config_skills() {
@@ -685,21 +805,34 @@ ticket_comment() {
     *) return 0 ;;
   esac
   [[ -n "${SUMMARY:-}" ]] || return 0
-  [[ -n "${OWNER:-}" && -n "${REPO:-}" ]] || return 0
   [[ -n "${ISSUE:-}" || -n "${PR:-}" ]] || return 0
-  command -v gh >/dev/null 2>&1 || { warn_mem "gh not installed"; return 0; }
   body="$SUMMARY"
-  if [[ -n "${PR:-}" ]]; then
+  if [[ -n "${PR:-}" && -n "${OWNER:-}" && -n "${REPO:-}" ]]; then
     body+=$'\n\n'"[PR ${PR}]($(pr_url "$PR"))"
   fi
   err="$(mktemp)"
   set +e
   if [[ -n "${ISSUE:-}" ]]; then
-    gh issue comment "$ISSUE" -R "${OWNER}/${REPO}" --body "$body" >/dev/null 2>"$err"
+    load_tracker
+    if [[ -n "$TRACKER_CMD" ]]; then
+      "$TRACKER_CMD" comment "$ISSUE" --body "$body" >/dev/null 2>"$err"
+      code=$?
+    elif [[ "$TRACKER" == github ]]; then
+      [[ -n "${OWNER:-}" && -n "${REPO:-}" ]] || { rm -f "$err"; return 0; }
+      command -v gh >/dev/null 2>&1 || { warn_mem "gh not installed"; rm -f "$err"; return 0; }
+      gh issue comment "$ISSUE" -R "${OWNER}/${REPO}" --body "$body" >/dev/null 2>"$err"
+      code=$?
+    else
+      warn_mem "Need FACTORY_TRACKER_CMD to comment on tracker $TRACKER"
+      rm -f "$err"
+      return 0
+    fi
   else
+    [[ -n "${OWNER:-}" && -n "${REPO:-}" ]] || { rm -f "$err"; return 0; }
+    command -v gh >/dev/null 2>&1 || { warn_mem "gh not installed"; rm -f "$err"; return 0; }
     gh pr comment "$PR" -R "${OWNER}/${REPO}" --body "$body" >/dev/null 2>"$err"
+    code=$?
   fi
-  code=$?
   set -e
   if [[ $code -ne 0 ]]; then
     warn_mem "$(cat "$err")"
@@ -831,15 +964,17 @@ run_mem_lane() {
 }
 
 floor_classify() {
-  local name
-  command -v gh >/dev/null 2>&1 || { printf '%s\n' feature; return 0; }
-  [[ -n "$OWNER" && -n "$REPO" ]] || { printf '%s\n' feature; return 0; }
-  while IFS= read -r name; do
+  local name labels
+  ticket_get || true
+  labels="${TICKET_LABELS:-}"
+  [[ -n "$labels" ]] || { printf '%s\n' feature; return 0; }
+  labels="${labels//,/ }"
+  for name in $labels; do
     case "$name" in
       bug) printf '%s\n' bug; return 0 ;;
       documentation|docs) printf '%s\n' docs; return 0 ;;
     esac
-  done < <(gh issue view "$ISSUE" -R "${OWNER}/${REPO}" --json labels --template '{{range .labels}}{{.name}}{{"\n"}}{{end}}' 2>/dev/null || true)
+  done
   printf '%s\n' feature
 }
 
@@ -1074,7 +1209,7 @@ case "$LANE" in
     RULES="$(cat "$FACTORY/lanes/${LANE}.md")"$'\n'"$HARD"
     CONVENTIONS="$(conventions_rules "$DIR")"
     [[ -z "$CONVENTIONS" ]] || RULES+=$'\n'"$CONVENTIONS"
-    run_mem_lane "$LANE" "$DIR" "$RULES" "Implement GitHub issue $(issue_url "$ISSUE") in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."
+    run_mem_lane "$LANE" "$DIR" "$RULES" "Implement this ticket in the ${REPO} checkout. Open a PR against main. Print the PR URL. Do not merge."$'\n\n'"$(ticket_context)"
     exit $?
     ;;
   review)
@@ -1106,7 +1241,12 @@ case "$LANE" in
   lead|tech-lead|cto)
     need_issue
     mem_read_context
-    prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}. After tickets exist, start factory.sh floor --repo ${REPO:-<repo>} --issue ${ISSUE} (or one factory.sh lane). Dispatch is factory.sh only. Writing product code, leaving a review, or watching CI in this session is a failed run."
+    load_tracker
+    prompt="Ticket or update work for issue ${ISSUE}. Follow /to-tickets. Owning repo: ${REPO:-unknown}. Owner: ${OWNER:-unknown}. After tickets exist, start factory.sh floor --repo ${REPO:-<repo>} --issue ${ISSUE} (or one factory.sh lane). Dispatch is factory.sh only. Writing product code, leaving a review, or watching CI in this session is a failed run. PRs stay on GitHub."
+    if [[ "$TRACKER" != github ]]; then
+      prompt+=$'\n'"Publish new tickets on the configured tracker, not GitHub issues."
+    fi
+    prompt+=$'\n\n'"$(ticket_context)"
     if [[ -n "${MEM_CONTEXT:-}" ]]; then
       prompt+=$'\n\n'"Factory memory:"$'\n'"$MEM_CONTEXT"
     fi

--- a/tests/bug.sh
+++ b/tests/bug.sh
@@ -65,6 +65,37 @@ exit "${AGENT_EXIT:-0}"
 EOF
 chmod +x "$TMP/bin/runner"
 
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/gh"
+cmd1="${1:-}"
+cmd2="${2:-}"
+body=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body) body="${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ -n "$body" ]]; then
+  printf '%s\n' "$body" > "$dump/comment-body"
+fi
+case "$cmd1 $cmd2" in
+  "issue view")
+    printf '%s\n' 'id=5'
+    printf '%s\n' 'title=Fix the checkout drop-off'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/5'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=bug,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Reproduce then fix.'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+
 run_bug() {
   PATH="$TMP/bin:$PATH" \
     FAKE_DUMP="$DUMP" \
@@ -178,6 +209,7 @@ for cmd in bash mkdir date sed git grep dirname cat rm mktemp printf; do
   [[ -n "$src" ]] && ln -sf "$src" "$hid/$cmd"
 done
 cp "$TMP/bin/runner" "$hid/runner"
+cp "$TMP/bin/gh" "$hid/gh"
 rm -rf "$DUMP" "$TMP/memory"
 mkdir -p "$DUMP"
 set +e

--- a/tests/conventions.sh
+++ b/tests/conventions.sh
@@ -35,6 +35,17 @@ chmod +x "$TMP/bin/runner"
 
 cat > "$TMP/bin/gh" << 'EOF'
 #!/usr/bin/env bash
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' 'id=6'
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/6'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
 exit 0
 EOF
 chmod +x "$TMP/bin/gh"

--- a/tests/floor.sh
+++ b/tests/floor.sh
@@ -50,8 +50,13 @@ if [[ -f "$dump/dispatched" ]]; then
 fi
 case "$1 $2" in
   "issue view")
-    printf '%s\n' 'ready-for-agent'
-    printf '%s\n' 'enhancement'
+    printf '%s\n' 'id=12'
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/12'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=ready-for-agent,enhancement'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
     ;;
   "pr view")
     if [[ "$*" == *reviews* ]]; then

--- a/tests/infer.sh
+++ b/tests/infer.sh
@@ -27,6 +27,23 @@ exit 0
 EOF
 chmod +x "$TMP/bin/runner"
 
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' "id=${3:-}"
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/12'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+
 PATH="$TMP/bin:$PATH" FAKE_DUMP="$DUMP" FACTORY_WORKSPACE="$WS" FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
   "$FACTORY" feature --issue 12 >"$TMP/out" 2>"$TMP/err"
 [[ -f "$DUMP/ran" ]] || fail "should infer owner/repo from origin and run, err=$(cat "$TMP/err")"

--- a/tests/lanes.sh
+++ b/tests/lanes.sh
@@ -127,6 +127,17 @@ if [[ "${GH_FAIL:-}" == 1 && "$cmd1" == "issue" && "$cmd2" == "comment" ]]; then
   echo "comment failed" >&2
   exit 1
 fi
+case "$cmd1 $cmd2" in
+  "issue view")
+    printf '%s\n' 'id=6'
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/6'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
 exit 0
 EOF
 chmod +x "$TMP/bin/gh"

--- a/tests/lead.sh
+++ b/tests/lead.sh
@@ -73,8 +73,13 @@ if [[ -f "$dump/dispatched" ]]; then
 fi
 case "$1 $2" in
   "issue view")
-    printf '%s\n' 'ready-for-agent'
-    printf '%s\n' 'enhancement'
+    printf '%s\n' 'id=7'
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/7'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=ready-for-agent,enhancement'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
     ;;
   "pr view")
     if [[ "$*" == *reviews* ]]; then

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -36,6 +36,23 @@ EOF
   chmod +x "$BIN/$name"
 }
 
+cat > "$BIN/gh" << 'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' 'id=1'
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/1'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$BIN/gh"
+
 # No worker CLI
 set +e
 PATH="$BIN" FACTORY_RUNNER= "$FACTORY" feature --repo widgets --issue 1 >"$TMP/out" 2>"$TMP/err"

--- a/tests/tracker.sh
+++ b/tests/tracker.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FACTORY="$ROOT/factory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export FACTORY_MEMORY_DB="$TMP/memory/factory.db"
+unset FACTORY_RUNNER
+unset FACTORY_SKIP_TICKET_COMMENT
+unset FACTORY_TRACKER_CMD
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+fn_body() {
+  local name="$1"
+  awk -v n="$name" '
+    $0 ~ "^" n "\\(\\)" {on=1}
+    on {print}
+    on && /^}$/ {exit}
+  ' "$ROOT/factory.sh"
+}
+
+WS="$TMP/workspace"
+mkdir -p "$WS/widgets"
+git -C "$WS/widgets" init -q
+git -C "$WS/widgets" remote add origin "https://github.com/acme/widgets.git"
+
+DUMP="$TMP/dump"
+mkdir -p "$DUMP" "$TMP/bin"
+
+cat > "$TMP/bin/runner" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p) printf '%s\n' "$2" > "$dump/prompt"; shift 2 ;;
+    --rules) printf '%s\n' "$2" > "$dump/rules"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+: > "$dump/ran"
+exit 0
+EOF
+chmod +x "$TMP/bin/runner"
+
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/gh"
+cmd1="${1:-}"
+cmd2="${2:-}"
+body=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body) body="${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ -n "$body" ]]; then
+  printf '%s\n' "$body" > "$dump/comment-body"
+fi
+case "$cmd1 $cmd2" in
+  "issue view")
+    printf '%s\n' 'id=6'
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/6'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+
+cat > "$TMP/bin/mcp-ticket" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/mcp"
+cmd="${1:-}"
+id="${2:-}"
+body=""
+shift $(( $# > 0 ? 1 : 0 )) || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body) body="${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$cmd" in
+  get)
+    printf '%s\n' "id=$id"
+    printf '%s\n' 'title=MCP tracked ticket'
+    printf '%s\n' 'url=https://linear.app/acme/issue/ABC-123'
+    printf '%s\n' 'status=started'
+    printf '%s\n' 'labels=bug,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Fix the checkout drop-off.'
+    ;;
+  comment)
+    printf '%s\n' "$body" > "$dump/mcp-comment"
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/mcp-ticket"
+
+run_env() {
+  PATH="$TMP/bin:$PATH" \
+    FAKE_DUMP="$DUMP" \
+    FACTORY_SH="$FACTORY" \
+    FACTORY_WORKSPACE="$WS" \
+    FACTORY_OWNER=acme \
+    FACTORY_RUNNER=runner FACTORY_HARNESS=claude \
+    "$@"
+}
+
+reset_dump() {
+  rm -rf "$DUMP" "$TMP/memory"
+  mkdir -p "$DUMP"
+}
+
+# GitHub default: factory fetches ticket context and hands it to the lane
+reset_dump
+run_env "$FACTORY" feature --repo widgets --issue 6 >"$TMP/out" 2>"$TMP/err"
+[[ -f "$DUMP/ran" ]] || fail "github default should still run feature, err=$(cat "$TMP/err")"
+grep -q "issue view" "$DUMP/gh" || fail "github default should fetch the ticket through gh: $(cat "$DUMP/gh")"
+for field in 'id: 6' 'title: Add widgets list' 'url: https://github.com/acme/widgets/issues/6' 'status: open' 'labels: enhancement,ready-for-agent' 'Ship a list of widgets.'; do
+  grep -Fq "$field" "$DUMP/prompt" || fail "github default prompt missing $field: $(cat "$DUMP/prompt")"
+done
+grep -q "gh issue" "$DUMP/prompt" && fail "lanes must not be told to call gh issue APIs: $(cat "$DUMP/prompt")"
+grep -q "Implement GitHub issue" "$DUMP/prompt" && fail "prompt should hand ticket context, not a GitHub issue URL to fetch: $(cat "$DUMP/prompt")"
+
+# GitHub default comments still go through gh issue comment
+grep -q "issue comment 6" "$DUMP/gh" || fail "github default comments should use gh issue comment: $(cat "$DUMP/gh")"
+
+# MCP connector: factory receives the ticket from FACTORY_TRACKER_CMD, not gh
+reset_dump
+FACTORY_TRACKER_CMD="$TMP/bin/mcp-ticket" run_env "$FACTORY" feature --repo widgets --issue ABC-123 >"$TMP/out" 2>"$TMP/err"
+[[ -f "$DUMP/ran" ]] || fail "mcp tracker should still run feature, err=$(cat "$TMP/err")"
+grep -q "get ABC-123" "$DUMP/mcp" || fail "factory should get the ticket from the MCP command: $(cat "$DUMP/mcp" 2>/dev/null || true)"
+if [[ -f "$DUMP/gh" ]] && grep -q "issue view" "$DUMP/gh"; then
+  fail "mcp tracker must not call gh issue view: $(cat "$DUMP/gh")"
+fi
+for field in 'id: ABC-123' 'title: MCP tracked ticket' 'url: https://linear.app/acme/issue/ABC-123' 'status: started' 'labels: bug,ready-for-agent' 'Fix the checkout drop-off.'; do
+  grep -Fq "$field" "$DUMP/prompt" || fail "mcp prompt missing $field: $(cat "$DUMP/prompt")"
+done
+grep -q "gh issue" "$DUMP/prompt" && fail "mcp prompt must not tell lanes to call gh issue: $(cat "$DUMP/prompt")"
+
+# MCP comments go through the plug, not gh issue comment
+grep -q "comment ABC-123" "$DUMP/mcp" || fail "ticket comments should go through the MCP command: $(cat "$DUMP/mcp")"
+[[ -f "$DUMP/mcp-comment" ]] || fail "MCP comment body missing"
+if [[ -f "$DUMP/gh" ]] && grep -q "issue comment" "$DUMP/gh"; then
+  fail "mcp tracker must not gh issue comment: $(cat "$DUMP/gh")"
+fi
+
+# mem write done with MCP still comments through the plug
+reset_dump
+FACTORY_TRACKER_CMD="$TMP/bin/mcp-ticket" run_env "$FACTORY" mem write \
+  --lane feature --status done --harness grok --issue ABC-123 --owner acme --repo widgets \
+  --project acme/widgets --summary "Shipped the list" >/dev/null
+grep -q "comment ABC-123" "$DUMP/mcp" || fail "mem write comments should use the plug: $(cat "$DUMP/mcp" 2>/dev/null || true)"
+if [[ -f "$DUMP/gh" ]] && grep -q "issue comment" "$DUMP/gh"; then
+  fail "mem write with MCP must not gh issue comment: $(cat "$DUMP/gh")"
+fi
+[[ "$(cat "$DUMP/mcp-comment")" == "Shipped the list" ]] || fail "plug comment body want Shipped the list got $(cat "$DUMP/mcp-comment")"
+
+# Review comments stay on GitHub PRs even when the ticket plug is MCP
+reset_dump
+FACTORY_TRACKER_CMD="$TMP/bin/mcp-ticket" run_env "$FACTORY" mem write \
+  --lane review --status done --harness grok --pr 40 --owner acme --repo widgets \
+  --project acme/widgets --summary "Left review comments" >/dev/null
+grep -q "pr comment 40" "$DUMP/gh" || fail "review comments must stay on GitHub: $(cat "$DUMP/gh" 2>/dev/null || true)"
+if [[ -f "$DUMP/mcp" ]] && grep -q comment "$DUMP/mcp"; then
+  fail "review must not comment through the issue tracker plug: $(cat "$DUMP/mcp")"
+fi
+
+# Tracker linear without an MCP command must not call gh for ticket context
+reset_dump
+mkdir -p "$WS/widgets/.factory"
+printf 'tracker=linear\nteam=ABC\n' > "$WS/widgets/.factory/config"
+run_env "$FACTORY" feature --repo widgets --issue ABC-123 >"$TMP/out" 2>"$TMP/err"
+[[ -f "$DUMP/ran" ]] || fail "linear name without MCP should still run, err=$(cat "$TMP/err")"
+if [[ -f "$DUMP/gh" ]] && grep -q "issue view" "$DUMP/gh"; then
+  fail "tracker linear must not gh issue view: $(cat "$DUMP/gh")"
+fi
+grep -q "ABC-123" "$DUMP/prompt" || fail "linear name should still pass the ticket id: $(cat "$DUMP/prompt")"
+rm -rf "$WS/widgets/.factory"
+
+# Floor classification uses plug labels, not a raw gh issue call, when MCP is set
+reset_dump
+cat > "$TMP/bin/runner" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+: > "$dump/after-feature"
+printf 'grok\n' >> "$dump/dispatched"
+exit 0
+EOF
+chmod +x "$TMP/bin/runner"
+set +e
+FACTORY_TRACKER_CMD="$TMP/bin/mcp-ticket" run_env "$FACTORY" floor --repo widgets --issue ABC-123 >"$TMP/fout" 2>"$TMP/ferr"
+set -e
+grep -q "dispatch bug" "$TMP/fout" || fail "floor should classify from plug labels, got: $(cat "$TMP/fout")"
+if [[ -f "$DUMP/gh" ]] && grep -q "issue view" "$DUMP/gh"; then
+  fail "floor must not gh issue view when MCP is set: $(cat "$DUMP/gh")"
+fi
+grep -q "pr view" "$DUMP/gh" || fail "PRs stay on GitHub: $(cat "$DUMP/gh" 2>/dev/null || true)"
+
+# close-linked stays GitHub-on-merge
+close_fn="$(fn_body close_linked_issues)"
+echo "$close_fn" | grep -q 'gh issue close' || fail "close-linked must stay GitHub issue close"
+echo "$close_fn" | grep -q 'closingIssuesReferences' || fail "close-linked must stay GitHub-linked issues"
+
+# PRs, reviews, checks stay on GitHub
+grep -q 'gh pr checks' "$FACTORY" || fail "CI should still use gh pr checks"
+grep -q 'gh pr view' "$FACTORY" || fail "PR capture should still use gh pr view"
+grep -q 'gh pr comment' "$FACTORY" || fail "review comments should still use gh pr comment"
+
+# No Linear or Jira adapter code
+if [[ -d "$ROOT/tracker/adapters" ]]; then
+  fail "this slice must not add tracker adapter folders"
+fi
+if grep -RIn -E 'linear\.app/api|api\.linear\.app|atlassian\.net|jira\.com/rest' "$ROOT" --exclude-dir .git --exclude 'tracker.sh'; then
+  fail "no Linear or Jira API adapter code"
+fi
+if grep -RIn -E 'LINEAR_API|JIRA_API|JIRA_TOKEN|LINEAR_KEY' "$ROOT" --exclude-dir .git --exclude 'tracker.sh'; then
+  fail "no Linear or Jira API secrets or clients"
+fi
+
+# README documents how to point at an issue-tracking MCP connector
+grep -qi "MCP" "$ROOT/README.md" || fail "README should document issue-tracking MCP connectors"
+grep -q "FACTORY_TRACKER_CMD" "$ROOT/README.md" || fail "README should document FACTORY_TRACKER_CMD"
+[[ -f "$ROOT/tracker/CONTRACT.md" ]] || fail "tracker/CONTRACT.md should describe the ticket plug"
+
+echo "ok tracker"

--- a/tests/tracker.sh
+++ b/tests/tracker.sh
@@ -187,7 +187,117 @@ if [[ -f "$DUMP/gh" ]] && grep -q "issue view" "$DUMP/gh"; then
   fail "tracker linear must not gh issue view: $(cat "$DUMP/gh")"
 fi
 grep -q "ABC-123" "$DUMP/prompt" || fail "linear name should still pass the ticket id: $(cat "$DUMP/prompt")"
+
+# Lead still publishes GitHub issues; ticket_context is extra context only
+reset_dump
+cat > "$TMP/bin/runner" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p)
+      if [[ ! -f "$dump/prompt" ]]; then
+        printf '%s\n' "$2" > "$dump/prompt"
+      fi
+      shift 2
+      ;;
+    --rules)
+      if [[ ! -f "$dump/rules" ]]; then
+        printf '%s\n' "$2" > "$dump/rules"
+      fi
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+: > "$dump/ran"
+exit 0
+EOF
+chmod +x "$TMP/bin/runner"
+run_env "$FACTORY" lead --repo widgets --issue ABC-123 >"$TMP/lout" 2>"$TMP/lerr" || true
+[[ -f "$DUMP/prompt" ]] || fail "lead should still run on tracker linear, err=$(cat "$TMP/lerr")"
+grep -q "Publish new tickets on the configured tracker" "$DUMP/prompt" && fail "lead must not change ticket publish workflow: $(cat "$DUMP/prompt")"
+grep -q "ABC-123" "$DUMP/prompt" || fail "lead should still receive ticket context: $(cat "$DUMP/prompt")"
+grep -q "Publish new tickets on the configured tracker" "$FACTORY" && fail "lead must not tell the agent to publish on the configured tracker"
+cat > "$TMP/bin/runner" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p) printf '%s\n' "$2" > "$dump/prompt"; shift 2 ;;
+    --rules) printf '%s\n' "$2" > "$dump/rules"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+: > "$dump/ran"
+exit 0
+EOF
+chmod +x "$TMP/bin/runner"
 rm -rf "$WS/widgets/.factory"
+
+# Dead FACTORY_TRACKER_CMD must warn and must not invent a ticket
+reset_dump
+cat > "$TMP/bin/dead-tracker" << 'EOF'
+#!/usr/bin/env bash
+echo "tracker down" >&2
+exit 1
+EOF
+chmod +x "$TMP/bin/dead-tracker"
+FACTORY_TRACKER_CMD="$TMP/bin/dead-tracker" run_env "$FACTORY" feature --repo widgets --issue ABC-123 >"$TMP/out" 2>"$TMP/err"
+grep -q "tracker down" "$TMP/err" || fail "dead tracker get should warn with the plug error: $(cat "$TMP/err")"
+if [[ -f "$DUMP/prompt" ]] && grep -q "title:" "$DUMP/prompt"; then
+  fail "dead get should not invent ticket fields: $(cat "$DUMP/prompt")"
+fi
+
+# Unstructured gh output is not a ticket record
+reset_dump
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/gh"
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' 'ready-for-agent'
+    printf '%s\n' 'enhancement'
+    ;;
+  "issue comment") exit 0 ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+run_env "$FACTORY" feature --repo widgets --issue 6 >"$TMP/out" 2>"$TMP/err"
+[[ -f "$DUMP/prompt" ]] || fail "unstructured gh should still run feature"
+grep -q "labels:" "$DUMP/prompt" && fail "unstructured lines must not become labels: $(cat "$DUMP/prompt")"
+cat > "$TMP/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/gh"
+cmd1="${1:-}"
+cmd2="${2:-}"
+body=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body) body="${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ -n "$body" ]]; then
+  printf '%s\n' "$body" > "$dump/comment-body"
+fi
+case "$cmd1 $cmd2" in
+  "issue view")
+    printf '%s\n' 'id=6'
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/6'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
 
 # Floor classification uses plug labels, not a raw gh issue call, when MCP is set
 reset_dump
@@ -207,6 +317,35 @@ if [[ -f "$DUMP/gh" ]] && grep -q "issue view" "$DUMP/gh"; then
   fail "floor must not gh issue view when MCP is set: $(cat "$DUMP/gh")"
 fi
 grep -q "pr view" "$DUMP/gh" || fail "PRs stay on GitHub: $(cat "$DUMP/gh" 2>/dev/null || true)"
+
+# A label with spaces is not word-split into a fake bug
+reset_dump
+cat > "$TMP/bin/mcp-spaces" << 'EOF'
+#!/usr/bin/env bash
+dump="${FAKE_DUMP:?}"
+printf '%s\n' "$*" >> "$dump/mcp"
+case "${1:-}" in
+  get)
+    printf '%s\n' "id=${2:-}"
+    printf '%s\n' 'title=Not a bug'
+    printf '%s\n' 'url=https://example/issues/9'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=not a bug,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Keep the spaces.'
+    ;;
+  comment) ;;
+esac
+exit 0
+EOF
+chmod +x "$TMP/bin/mcp-spaces"
+set +e
+FACTORY_TRACKER_CMD="$TMP/bin/mcp-spaces" run_env "$FACTORY" floor --repo widgets --issue 9 >"$TMP/sout" 2>"$TMP/serr"
+set -e
+grep -q "dispatch feature" "$TMP/sout" || fail "label 'not a bug' should classify as feature: $(cat "$TMP/sout")"
+if grep -q "dispatch bug" "$TMP/sout"; then
+  fail "word-split labels classified 'not a bug' as bug: $(cat "$TMP/sout")"
+fi
 
 # close-linked stays GitHub-on-merge
 close_fn="$(fn_body close_linked_issues)"
@@ -233,5 +372,20 @@ fi
 grep -qi "MCP" "$ROOT/README.md" || fail "README should document issue-tracking MCP connectors"
 grep -q "FACTORY_TRACKER_CMD" "$ROOT/README.md" || fail "README should document FACTORY_TRACKER_CMD"
 [[ -f "$ROOT/tracker/CONTRACT.md" ]] || fail "tracker/CONTRACT.md should describe the ticket plug"
+grep -q 'Jira are names in' "$ROOT/README.md" && fail "config tracker is github|linear; Jira is FACTORY_TRACKER_CMD only"
+grep -q 'Jira are names in' "$ROOT/tracker/CONTRACT.md" && fail "config tracker is github|linear; Jira is FACTORY_TRACKER_CMD only"
+
+# Plug runtime lives next to the contract, not in factory.sh
+[[ -f "$ROOT/tracker/tracker.sh" ]] || fail "get/parse/comment should live next to tracker/CONTRACT.md"
+grep -q 'tracker/tracker.sh' "$FACTORY" || fail "factory.sh should call tracker/tracker.sh"
+if grep -q 'parse_ticket_record' "$FACTORY"; then
+  fail "ticket parse should live in tracker/tracker.sh, not factory.sh"
+fi
+if grep -q 'github_ticket_get' "$FACTORY"; then
+  fail "github get should live in tracker/tracker.sh, not factory.sh"
+fi
+if grep -q 'TRACKER_TEAM' "$FACTORY" "$ROOT/tracker/tracker.sh"; then
+  fail "TRACKER_TEAM is unused until something reads it"
+fi
 
 echo "ok tracker"

--- a/tests/tracker.sh
+++ b/tests/tracker.sh
@@ -235,7 +235,7 @@ EOF
 chmod +x "$TMP/bin/runner"
 rm -rf "$WS/widgets/.factory"
 
-# Dead FACTORY_TRACKER_CMD must warn and must not invent a ticket
+# Dead FACTORY_TRACKER_CMD must fail closed: no lane, no fabricated ticket
 reset_dump
 cat > "$TMP/bin/dead-tracker" << 'EOF'
 #!/usr/bin/env bash
@@ -243,10 +243,15 @@ echo "tracker down" >&2
 exit 1
 EOF
 chmod +x "$TMP/bin/dead-tracker"
+set +e
 FACTORY_TRACKER_CMD="$TMP/bin/dead-tracker" run_env "$FACTORY" feature --repo widgets --issue ABC-123 >"$TMP/out" 2>"$TMP/err"
+dead_code=$?
+set -e
+[[ $dead_code -ne 0 ]] || fail "dead tracker get should fail the lane, err=$(cat "$TMP/err")"
 grep -q "tracker down" "$TMP/err" || fail "dead tracker get should warn with the plug error: $(cat "$TMP/err")"
-if [[ -f "$DUMP/prompt" ]] && grep -q "title:" "$DUMP/prompt"; then
-  fail "dead get should not invent ticket fields: $(cat "$DUMP/prompt")"
+[[ ! -f "$DUMP/ran" ]] || fail "dead tracker must not start the lane"
+if [[ -f "$DUMP/prompt" ]]; then
+  fail "dead get should not hand the lane a ticket: $(cat "$DUMP/prompt")"
 fi
 
 # Unstructured gh output is not a ticket record
@@ -265,9 +270,15 @@ esac
 exit 0
 EOF
 chmod +x "$TMP/bin/gh"
+set +e
 run_env "$FACTORY" feature --repo widgets --issue 6 >"$TMP/out" 2>"$TMP/err"
-[[ -f "$DUMP/prompt" ]] || fail "unstructured gh should still run feature"
-grep -q "labels:" "$DUMP/prompt" && fail "unstructured lines must not become labels: $(cat "$DUMP/prompt")"
+unstruct_code=$?
+set -e
+[[ $unstruct_code -ne 0 ]] || fail "unstructured gh must fail closed, err=$(cat "$TMP/err")"
+[[ ! -f "$DUMP/ran" ]] || fail "unstructured gh must not start the lane"
+if [[ -f "$DUMP/prompt" ]]; then
+  fail "unstructured gh must not hand the lane a ticket: $(cat "$DUMP/prompt")"
+fi
 cat > "$TMP/bin/gh" << 'EOF'
 #!/usr/bin/env bash
 dump="${FAKE_DUMP:?}"
@@ -317,6 +328,18 @@ if [[ -f "$DUMP/gh" ]] && grep -q "issue view" "$DUMP/gh"; then
   fail "floor must not gh issue view when MCP is set: $(cat "$DUMP/gh")"
 fi
 grep -q "pr view" "$DUMP/gh" || fail "PRs stay on GitHub: $(cat "$DUMP/gh" 2>/dev/null || true)"
+
+# Floor must not dispatch when get fails
+reset_dump
+set +e
+FACTORY_TRACKER_CMD="$TMP/bin/dead-tracker" run_env "$FACTORY" floor --repo widgets --issue ABC-123 >"$TMP/fout" 2>"$TMP/ferr"
+floor_dead=$?
+set -e
+[[ $floor_dead -ne 0 ]] || fail "dead get must fail floor, err=$(cat "$TMP/ferr")"
+if grep -q "dispatch " "$TMP/fout"; then
+  fail "dead get must not dispatch a lane: $(cat "$TMP/fout")"
+fi
+grep -q "tracker down" "$TMP/ferr" || fail "floor dead get should surface the plug error: $(cat "$TMP/ferr")"
 
 # A label with spaces is not word-split into a fake bug
 reset_dump

--- a/tests/tracker.sh
+++ b/tests/tracker.sh
@@ -177,16 +177,35 @@ if [[ -f "$DUMP/mcp" ]] && grep -q comment "$DUMP/mcp"; then
   fail "review must not comment through the issue tracker plug: $(cat "$DUMP/mcp")"
 fi
 
-# Tracker linear without an MCP command must not call gh for ticket context
+# Tracker linear without FACTORY_TRACKER_CMD fails closed: no lane, no fabricated ticket
 reset_dump
 mkdir -p "$WS/widgets/.factory"
 printf 'tracker=linear\nteam=ABC\n' > "$WS/widgets/.factory/config"
+set +e
 run_env "$FACTORY" feature --repo widgets --issue ABC-123 >"$TMP/out" 2>"$TMP/err"
-[[ -f "$DUMP/ran" ]] || fail "linear name without MCP should still run, err=$(cat "$TMP/err")"
+linear_code=$?
+set -e
+[[ $linear_code -ne 0 ]] || fail "linear without MCP should fail closed, err=$(cat "$TMP/err")"
 if [[ -f "$DUMP/gh" ]] && grep -q "issue view" "$DUMP/gh"; then
   fail "tracker linear must not gh issue view: $(cat "$DUMP/gh")"
 fi
-grep -q "ABC-123" "$DUMP/prompt" || fail "linear name should still pass the ticket id: $(cat "$DUMP/prompt")"
+[[ ! -f "$DUMP/ran" ]] || fail "linear without MCP must not start the lane"
+if [[ -f "$DUMP/prompt" ]]; then
+  fail "linear without MCP must not hand the lane a ticket: $(cat "$DUMP/prompt")"
+fi
+grep -q "FACTORY_TRACKER_CMD" "$TMP/err" || fail "linear without MCP should ask for FACTORY_TRACKER_CMD: $(cat "$TMP/err")"
+
+# Floor must not dispatch when tracker is not github and no FACTORY_TRACKER_CMD
+reset_dump
+set +e
+run_env "$FACTORY" floor --repo widgets --issue ABC-123 >"$TMP/fout" 2>"$TMP/ferr"
+floor_linear=$?
+set -e
+[[ $floor_linear -ne 0 ]] || fail "linear without MCP must fail floor, err=$(cat "$TMP/ferr")"
+if grep -q "dispatch " "$TMP/fout"; then
+  fail "linear without MCP must not dispatch a lane: $(cat "$TMP/fout")"
+fi
+grep -q "FACTORY_TRACKER_CMD" "$TMP/ferr" || fail "floor linear without MCP should ask for FACTORY_TRACKER_CMD: $(cat "$TMP/ferr")"
 
 # Lead still publishes GitHub issues; ticket_context is extra context only
 reset_dump
@@ -214,8 +233,8 @@ done
 exit 0
 EOF
 chmod +x "$TMP/bin/runner"
-run_env "$FACTORY" lead --repo widgets --issue ABC-123 >"$TMP/lout" 2>"$TMP/lerr" || true
-[[ -f "$DUMP/prompt" ]] || fail "lead should still run on tracker linear, err=$(cat "$TMP/lerr")"
+FACTORY_TRACKER_CMD="$TMP/bin/mcp-ticket" run_env "$FACTORY" lead --repo widgets --issue ABC-123 >"$TMP/lout" 2>"$TMP/lerr" || true
+[[ -f "$DUMP/prompt" ]] || fail "lead should still run with the tracker plug, err=$(cat "$TMP/lerr")"
 grep -q "Publish new tickets on the configured tracker" "$DUMP/prompt" && fail "lead must not change ticket publish workflow: $(cat "$DUMP/prompt")"
 grep -q "ABC-123" "$DUMP/prompt" || fail "lead should still receive ticket context: $(cat "$DUMP/prompt")"
 grep -q "Publish new tickets on the configured tracker" "$FACTORY" && fail "lead must not tell the agent to publish on the configured tracker"

--- a/tracker/CONTRACT.md
+++ b/tracker/CONTRACT.md
@@ -44,7 +44,7 @@ comment <id> --body <text>
 
 ## Default
 
-No `FACTORY_TRACKER_CMD` and tracker `github` (or no config): `gh issue view` / `gh issue comment`. Tracker `linear` without a command does not call `gh` for tickets.
+No `FACTORY_TRACKER_CMD` and tracker `github` (or no config): `gh issue view` / `gh issue comment`. Tracker `linear` without a command does not call `gh` for tickets. Get fails. Set `FACTORY_TRACKER_CMD`.
 
 ## Configure
 

--- a/tracker/CONTRACT.md
+++ b/tracker/CONTRACT.md
@@ -1,0 +1,55 @@
+# Issue tracker contract
+
+The factory does not own an issue tracker. It loads a ticket and comments on it through one plug.
+
+GitHub is the default. `gh` implements the plug. Linear and Jira are names in `.factory/config`, not adapters in this repo.
+
+PRs, reviews, checks, and close-linked-on-merge stay on GitHub.
+
+## Ticket
+
+The plug returns these fields. `id` is opaque. It can be `47` or `ABC-123`.
+
+| Field | What it is |
+| --- | --- |
+| id | Tracker id |
+| title | Title |
+| body | Description |
+| labels | Comma-separated labels |
+| url | Ticket URL |
+| status | Open, started, done, or whatever the tracker uses |
+
+Stdout of `get`:
+
+```
+id=47
+title=Ship the list
+url=https://example/issues/47
+status=open
+labels=ready-for-agent,enhancement
+body:
+The rest is the ticket body.
+```
+
+## Command
+
+`FACTORY_TRACKER_CMD` is an executable. Point it at whatever talks to your harness MCP connector.
+
+```
+get <id>
+comment <id> --body <text>
+```
+
+`get` prints the record. `comment` posts `<text>` on that ticket. No other verbs. The factory hands `get` to lanes so they do not call GitHub issue APIs. Terminal memory writes (`done`, `blocked`, `failed`) call `comment`.
+
+## Default
+
+No `FACTORY_TRACKER_CMD` and tracker `github` (or no config): `gh issue view` / `gh issue comment`. Tracker `linear` without a command does not call `gh` for tickets.
+
+## Configure
+
+1. Add the GitHub, Linear, or Jira MCP connector to the harness.
+2. `factory.sh config tracker github` or `factory.sh config tracker linear --team <key>`.
+3. Export `FACTORY_TRACKER_CMD` to the command that speaks this contract.
+
+The factory does not ship Linear or Jira clients.

--- a/tracker/CONTRACT.md
+++ b/tracker/CONTRACT.md
@@ -2,7 +2,7 @@
 
 The factory does not own an issue tracker. It loads a ticket and comments on it through one plug.
 
-GitHub is the default. `gh` implements the plug. Linear and Jira are names in `.factory/config`, not adapters in this repo.
+GitHub is the default. `gh` implements the plug. `config tracker` writes github or linear into `.factory/config`. For Linear or Jira, export `FACTORY_TRACKER_CMD`. This repo does not ship those adapters.
 
 PRs, reviews, checks, and close-linked-on-merge stay on GitHub.
 

--- a/tracker/tracker.sh
+++ b/tracker/tracker.sh
@@ -121,9 +121,9 @@ ticket_get() {
 }
 
 ticket_context() {
-  ticket_get || true
+  ticket_get || return 1
   local out=""
-  out="id: ${TICKET_ID:-${ISSUE:-}}"
+  out="id: $TICKET_ID"
   [[ -z "$TICKET_TITLE" ]] || out+=$'\n'"title: $TICKET_TITLE"
   [[ -z "$TICKET_URL" ]] || out+=$'\n'"url: $TICKET_URL"
   [[ -z "$TICKET_STATUS" ]] || out+=$'\n'"status: $TICKET_STATUS"

--- a/tracker/tracker.sh
+++ b/tracker/tracker.sh
@@ -110,8 +110,8 @@ ticket_get() {
     fi
     rm -f "$err"
   else
-    TICKET_ID="$ISSUE"
-    return 0
+    printf '%s\n' "Need FACTORY_TRACKER_CMD to get ticket from tracker $TRACKER" >&2
+    return 1
   fi
   parse_ticket_record "$raw"
   if [[ -z "$TICKET_ID" ]]; then

--- a/tracker/tracker.sh
+++ b/tracker/tracker.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+TRACKER="github"
+TRACKER_CMD=""
+TICKET_ID=""
+TICKET_TITLE=""
+TICKET_URL=""
+TICKET_STATUS=""
+TICKET_LABELS=""
+TICKET_BODY=""
+
+load_tracker() {
+  local dir="" line
+  TRACKER="github"
+  TRACKER_CMD="${FACTORY_TRACKER_CMD:-}"
+  if [[ -n "${REPO:-}" && -d "$WORKSPACE/$REPO" ]]; then
+    dir="$(git -C "$WORKSPACE/$REPO" rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  if [[ -z "$dir" ]]; then
+    dir="$(git rev-parse --show-toplevel 2>/dev/null || git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  [[ -n "$dir" && -f "$dir/.factory/config" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      tracker=*) TRACKER="${line#tracker=}" ;;
+    esac
+  done < "$dir/.factory/config"
+}
+
+parse_ticket_record() {
+  local in_body=0 line
+  TICKET_ID=""
+  TICKET_TITLE=""
+  TICKET_URL=""
+  TICKET_STATUS=""
+  TICKET_LABELS=""
+  TICKET_BODY=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$in_body" -eq 1 ]]; then
+      if [[ -n "$TICKET_BODY" ]]; then
+        TICKET_BODY+=$'\n'"$line"
+      else
+        TICKET_BODY="$line"
+      fi
+      continue
+    fi
+    case "$line" in
+      id=*) TICKET_ID="${line#id=}" ;;
+      title=*) TICKET_TITLE="${line#title=}" ;;
+      url=*) TICKET_URL="${line#url=}" ;;
+      status=*) TICKET_STATUS="${line#status=}" ;;
+      labels=*)
+        TICKET_LABELS="${line#labels=}"
+        TICKET_LABELS="${TICKET_LABELS%,}"
+        ;;
+      body:*)
+        in_body=1
+        TICKET_BODY="${line#body:}"
+        TICKET_BODY="${TICKET_BODY# }"
+        ;;
+    esac
+  done <<< "$1"
+}
+
+github_ticket_get() {
+  command -v gh >/dev/null 2>&1 || return 1
+  [[ -n "${OWNER:-}" && -n "${REPO:-}" && -n "${ISSUE:-}" ]] || return 1
+  gh issue view "$ISSUE" -R "${OWNER}/${REPO}" --json number,title,body,labels,url,state --template $'id={{.number}}\ntitle={{.title}}\nurl={{.url}}\nstatus={{.state}}\nlabels={{range .labels}}{{.name}},{{end}}\nbody:\n{{.body}}\n'
+}
+
+ticket_get_failed() {
+  local err="$1" msg
+  msg="$(cat "$err")"
+  rm -f "$err"
+  [[ -n "$msg" ]] || msg="tracker get failed for ${ISSUE:-}"
+  printf '%s\n' "$msg" >&2
+  return 1
+}
+
+ticket_get() {
+  local raw="" err code
+  TICKET_ID=""
+  TICKET_TITLE=""
+  TICKET_URL=""
+  TICKET_STATUS=""
+  TICKET_LABELS=""
+  TICKET_BODY=""
+  [[ -n "${ISSUE:-}" ]] || return 1
+  load_tracker
+  if [[ -n "$TRACKER_CMD" ]]; then
+    err="$(mktemp)"
+    set +e
+    raw="$("$TRACKER_CMD" get "$ISSUE" 2>"$err")"
+    code=$?
+    set -e
+    if [[ $code -ne 0 || -z "$raw" ]]; then
+      ticket_get_failed "$err"
+      return 1
+    fi
+    rm -f "$err"
+  elif [[ "$TRACKER" == github ]]; then
+    err="$(mktemp)"
+    set +e
+    raw="$(github_ticket_get 2>"$err")"
+    code=$?
+    set -e
+    if [[ $code -ne 0 || -z "$raw" ]]; then
+      ticket_get_failed "$err"
+      return 1
+    fi
+    rm -f "$err"
+  else
+    TICKET_ID="$ISSUE"
+    return 0
+  fi
+  parse_ticket_record "$raw"
+  if [[ -z "$TICKET_ID" ]]; then
+    printf '%s\n' "tracker get failed for $ISSUE" >&2
+    return 1
+  fi
+}
+
+ticket_context() {
+  ticket_get || true
+  local out=""
+  out="id: ${TICKET_ID:-${ISSUE:-}}"
+  [[ -z "$TICKET_TITLE" ]] || out+=$'\n'"title: $TICKET_TITLE"
+  [[ -z "$TICKET_URL" ]] || out+=$'\n'"url: $TICKET_URL"
+  [[ -z "$TICKET_STATUS" ]] || out+=$'\n'"status: $TICKET_STATUS"
+  [[ -z "$TICKET_LABELS" ]] || out+=$'\n'"labels: $TICKET_LABELS"
+  [[ -z "$TICKET_BODY" ]] || out+=$'\n\n'"$TICKET_BODY"
+  printf '%s\n' "$out"
+}
+
+ticket_issue_comment() {
+  local body="$1" err="$2"
+  load_tracker
+  if [[ -n "$TRACKER_CMD" ]]; then
+    "$TRACKER_CMD" comment "$ISSUE" --body "$body" >/dev/null 2>"$err"
+    return $?
+  fi
+  if [[ "$TRACKER" == github ]]; then
+    [[ -n "${OWNER:-}" && -n "${REPO:-}" ]] || return 0
+    command -v gh >/dev/null 2>&1 || { warn_mem "gh not installed"; return 0; }
+    gh issue comment "$ISSUE" -R "${OWNER}/${REPO}" --body "$body" >/dev/null 2>"$err"
+    return $?
+  fi
+  warn_mem "Need FACTORY_TRACKER_CMD to comment on tracker $TRACKER"
+  return 0
+}


### PR DESCRIPTION
Lanes take ticket context from a tracker plug next to tracker/CONTRACT.md, like telemetry. GitHub via gh is the default, FACTORY_TRACKER_CMD is the MCP connector, and PRs, reviews, checks, and close-linked stay on GitHub. Ticket: https://github.com/Kripu77/software-factory/issues/47