### PR TITLE
Set plugin versions to 1.1.2 and repair the red test suite

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "software-factory",
   "description": "Lanes, tickets, and a human merge. Same skills as Cursor, Grok, and Codex.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "Kripu Khadka"
   }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-factory",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Lanes, tickets, and a human merge. Skills for Codex.",
   "author": {
     "name": "Kripu Khadka"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "software-factory",
   "displayName": "Software factory",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Lanes, tickets, and a human merge. Skills and commands for Cursor, Claude, Grok, and Codex.",
   "author": {
     "name": "Kripu Khadka"

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-factory",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Lanes, tickets, and a human merge. Skills and slash commands for Grok Build.",
   "author": {
     "name": "Kripu Khadka"

--- a/README.md
+++ b/README.md
@@ -55,28 +55,28 @@ Add this GitHub repo as a marketplace and install software-factory at the Releas
 Claude Code:
 
 ```
-/plugin marketplace add Kripu77/software-factory@v1.1.1
+/plugin marketplace add Kripu77/software-factory@v1.1.2
 /plugin install software-factory@software-factory
 ```
 
 Grok Build:
 
 ```
-grok plugin install Kripu77/software-factory@v1.1.1 --trust
+grok plugin install Kripu77/software-factory@v1.1.2 --trust
 ```
 
-Or add this repo as a marketplace at tag `v1.1.1`, then install software-factory.
+Or add this repo as a marketplace at tag `v1.1.2`, then install software-factory.
 
 Codex:
 
 ```
-codex plugin marketplace add Kripu77/software-factory@v1.1.1
+codex plugin marketplace add Kripu77/software-factory@v1.1.2
 codex plugin add software-factory@software-factory
 ```
 
 Cursor:
 
-Add GitHub marketplace `Kripu77/software-factory` at tag `v1.1.1`, then install software-factory.
+Add GitHub marketplace `Kripu77/software-factory` at tag `v1.1.2`, then install software-factory.
 
 `/lead` loads. So do the other factory commands. Codex gets the skills.
 
@@ -99,8 +99,8 @@ grok          # or claude
 The versioned pack is on GitHub Releases. Set plugin versions in `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.grok-plugin/plugin.json`, and `.codex-plugin/plugin.json` to the tag without the `v`, then:
 
 ```bash
-git tag v1.1.1
-git push origin v1.1.1
+git tag v1.1.2
+git push origin v1.1.2
 ```
 
 Tag and push. A push to main does not cut a Release.

--- a/tests/atomic-commits.sh
+++ b/tests/atomic-commits.sh
@@ -54,6 +54,17 @@ chmod +x "$TMP/bin/runner"
 
 cat > "$TMP/bin/gh" << 'EOF'
 #!/usr/bin/env bash
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' "id=${3:-}"
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/6'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
 exit 0
 EOF
 chmod +x "$TMP/bin/gh"

--- a/tests/github-markdown.sh
+++ b/tests/github-markdown.sh
@@ -68,6 +68,17 @@ chmod +x "$TMP/bin/runner"
 
 cat > "$TMP/bin/gh" << 'EOF'
 #!/usr/bin/env bash
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' "id=${3:-}"
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/6'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
 exit 0
 EOF
 chmod +x "$TMP/bin/gh"

--- a/tests/mermaid.sh
+++ b/tests/mermaid.sh
@@ -146,6 +146,17 @@ chmod +x "$TMP/bin/runner"
 
 cat > "$TMP/bin/gh" << 'EOF'
 #!/usr/bin/env bash
+case "$1 $2" in
+  "issue view")
+    printf '%s\n' "id=${3:-}"
+    printf '%s\n' 'title=Add widgets list'
+    printf '%s\n' 'url=https://github.com/acme/widgets/issues/6'
+    printf '%s\n' 'status=open'
+    printf '%s\n' 'labels=enhancement,ready-for-agent'
+    printf '%s\n' 'body:'
+    printf '%s\n' 'Ship a list of widgets.'
+    ;;
+esac
 exit 0
 EOF
 chmod +x "$TMP/bin/gh"

--- a/tests/tracker.sh
+++ b/tests/tracker.sh
@@ -403,7 +403,7 @@ grep -q 'gh pr comment' "$FACTORY" || fail "review comments should still use gh 
 if [[ -d "$ROOT/tracker/adapters" ]]; then
   fail "this slice must not add tracker adapter folders"
 fi
-if grep -RIn -E 'linear\.app/api|api\.linear\.app|atlassian\.net|jira\.com/rest' "$ROOT" --exclude-dir .git --exclude 'tracker.sh'; then
+if grep -RIn -E 'linear\.app/api|api\.linear\.app|atlassian\.net|jira\.com/rest' "$ROOT" --exclude-dir .git --exclude-dir skills --exclude 'tracker.sh'; then
   fail "no Linear or Jira API adapter code"
 fi
 if grep -RIn -E 'LINEAR_API|JIRA_API|JIRA_TOKEN|LINEAR_KEY' "$ROOT" --exclude-dir .git --exclude 'tracker.sh'; then


### PR DESCRIPTION
`v1.1.2` never became an installable release. Two things were wrong, and both are fixed here.

## The manifests never moved

The `v1.1.2` tag pointed at a tree where all four plugin manifests still read `1.1.1`. `scripts/check-plugin-versions.sh` is step one of the Release workflow, so [run 33711084754](https://github.com/Kripu77/software-factory/actions/runs/33711084754) died after 7s:

```
.claude-plugin/plugin.json version 1.1.1 does not match v1.1.2
```

Neither `gh release create` nor `scripts/ship-grok-catalog.sh` ever ran, so the Grok catalog was never pinned. Every tag since `v1.0.0` has failed this same guard.

This bumps the four manifests and the README pins to `1.1.2` so the tag can be re-cut and the workflow can complete.

## main was red

`main` is also red at `4d3c377`, the commit `v1.1.2` tags. PR #57 was **green on its own branch** and still turned main red on merge — a semantic conflict, not a bad review.

#57 branched before `atomic-commits`, `github-markdown`, and `mermaid` landed, so it updated the stubs in `lanes` and `infer` but could not update those three. Their `gh` stubs were bare `exit 0`, which returns nothing for the tracker's `gh issue view`, so `ticket_get` bailed with `tracker get failed for 6`. Those three stubs now return the issue-view record, matching the shape #57 already used.

Separately, the tracker slice guard swept the entire repo for tracker hostnames. The vendored Mermaid reference `skills/mermaid/references/kanban.md` cites `atlassian.net` in a `ticketBaseUrl` example, which tripped it. The guard now skips `skills/` so it reads code rather than vendored prose.

## Verification

All 20 tests pass, including under the CI loop's `bash -e`:

```
$ bash -e -c 'for t in tests/*.sh; do bash "$t"; done'
ok actions
ok atomic-commits
...
ok tracker

$ bash scripts/check-plugin-versions.sh v1.1.2
(passes)
```

Kept as two commits, one thought each, per `atomic-commits`.